### PR TITLE
Implement Full CRUD Functionality for Profiles

### DIFF
--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -1,0 +1,5 @@
+class CheckInsController < ApplicationController
+  def index
+    @profile = Profile.find(params[:profile_id])
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,6 @@
 class ProfilesController < ApplicationController
+  before_action :set_profile, only: [:show, :edit, :update, :destroy]
+
   def new
     @profile = Profile.new
   end
@@ -6,13 +8,46 @@ class ProfilesController < ApplicationController
   def create
     @profile = Profile.new(profile_params)
     if @profile.save
-      redirect_to profile_check_ins_path(@profile), notice: "Profile created successfully"
+      redirect_to profile_path(@profile), notice: "Profile created successfully"
     else
+      flash.now[:alert] = 'Profile could not be created.'
       render :new, status: :unprocessable_entity
     end
   end
 
+  def show
+    # @profile = Profile.find(params[:id])
+    @check_ins = @profile.check_ins.order(checked_in_on: :desc)
+  end
+
+  def index
+    @profiles = Profile.all
+  end
+
+  def edit
+  end
+
+  def update
+    if @profile.update(profile_params)
+      redirect_to profile_path(@profile), notice: "Profile updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @profile.destroy
+    redirect_to profiles_path, notice: "Profile deleted successfully."
+  end
+
   private
+
+  def set_profile
+    @profile = Profile.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    flash[:alert] = "Profile not found."
+    redirect_to profiles_path
+  end
 
   def profile_params
     params.require(:profile).permit(:display_name, :default_unit)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,20 @@
+class ProfilesController < ApplicationController
+  def new
+    @profile = Profile.new
+  end
+
+  def create
+    @profile = Profile.new(profile_params)
+    if @profile.save
+      redirect_to profile_check_ins_path(@profile), notice: "Profile created successfully"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def profile_params
+    params.require(:profile).permit(:display_name, :default_unit)
+  end
+end

--- a/app/helpers/check_ins_helper.rb
+++ b/app/helpers/check_ins_helper.rb
@@ -1,0 +1,2 @@
+module CheckInsHelper
+end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/models/check_in.rb
+++ b/app/models/check_in.rb
@@ -1,0 +1,3 @@
+class CheckIn < ApplicationRecord
+    belongs_to :profile # Add model test for CheckIn
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,4 @@
+class Profile < ApplicationRecord
+    validates :display_name, presence: true, length: { minimum: 2, maximum: 50 }
+    validates :default_unit, presence: true, inclusion: { in: %w[in cm] }
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,4 +1,16 @@
 class Profile < ApplicationRecord
+    has_many :check_ins, dependent: :destroy # Update model test to cover this
     validates :display_name, presence: true, length: { minimum: 2, maximum: 50 }
     validates :default_unit, presence: true, inclusion: { in: %w[in cm] }
+
+    def formatted_default_unit
+        case default_unit
+        when "in"
+          "Inches"
+        when "cm"
+          "Centimeters"
+        else
+          default_unit
+        end
+      end
 end

--- a/app/views/check_ins/index.html.erb
+++ b/app/views/check_ins/index.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @profile.display_name %>'s Check-ins</h1>
+<p>No check-ins yet.</p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Home#index</h1>
+<p>Find me in app/views/home/index.html.erb</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,11 @@
   </head>
 
   <body>
+  <% flash.each do |type, message| %>
+    <div class="flash <%= type %>">
+      <%= message %>
+    </div>
+  <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with model: @profile do |form| %>
+  <% if @profile.errors.any? %>
+    <div>
+      <h2><%= pluralize(@profile.errors.count, "error") %> prevented this profile from being saved:</h2>
+      <ul>
+        <% @profile.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :display_name %>
+    <%= form.text_field :display_name %>
+  </div>
+
+  <div>
+    <%= form.label :default_unit %>
+    <%= form.select :default_unit, [["Inches", "in"], ["Centimeters", "cm"]], prompt: "Select a unit" %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/profiles/create.html.erb
+++ b/app/views/profiles/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Profiles#create</h1>
+<p>Find me in app/views/profiles/create.html.erb</p>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Profile</h1>
+
+<%= render "form" %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,0 +1,21 @@
+<h1>Profiles</h1>
+
+<div>
+  <%= link_to "Create New Profile", new_profile_path %>
+</div>
+
+<% if @profiles.any? %>
+  <ul>
+    <% @profiles.each do |profile| %>
+      <li>
+        <h2><%= link_to profile.display_name, profile_path(profile) %></h2>
+        <p>
+          <strong>Default unit:</strong>
+          <%= profile.formatted_default_unit %>
+        </p>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>No profiles yet.</p>
+<% end %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,28 +1,3 @@
 <h1>Create Profile</h1>
 
-<%= form_with model: @profile do |form| %>
-  <% if @profile.errors.any? %>
-    <div>
-      <h2><%= pluralize(@profile.errors.count, "error") %> prevented this profile from being saved:</h2>
-      <ul>
-        <% @profile.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div>
-    <%= form.label :display_name %>
-    <%= form.text_field :display_name %>
-  </div>
-
-  <div>
-    <%= form.label :default_unit %>
-    <%= form.select :default_unit, [["Inches", "in"], ["Centimeters", "cm"]] %>
-  </div>
-
-  <div>
-    <%= form.submit "Create Profile" %>
-  </div>
-<% end %>
+<%= render "form" %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,0 +1,28 @@
+<h1>Create Profile</h1>
+
+<%= form_with model: @profile do |form| %>
+  <% if @profile.errors.any? %>
+    <div>
+      <h2><%= pluralize(@profile.errors.count, "error") %> prevented this profile from being saved:</h2>
+      <ul>
+        <% @profile.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :display_name %>
+    <%= form.text_field :display_name %>
+  </div>
+
+  <div>
+    <%= form.label :default_unit %>
+    <%= form.select :default_unit, [["Inches", "in"], ["Centimeters", "cm"]] %>
+  </div>
+
+  <div>
+    <%= form.submit "Create Profile" %>
+  </div>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,28 @@
+<h1><%= @profile.display_name %></h1>
+
+<p>
+  <strong>Default unit:</strong>
+  <%= @profile.formatted_default_unit %>
+</p>
+
+<div>
+  <%= link_to "Edit Profile", edit_profile_path(@profile) %>
+  <%= button_to "Delete Profile", profile_path(@profile), method: :delete, data: { turbo_confirm: "Are you sure?" } %>
+</div>
+
+<h2>Check-ins</h2>
+
+<% if @check_ins.any? %>
+  <ul>
+    <% @check_ins.each do |check_in| %>
+      <li>
+        <strong>Date:</strong> <%= check_in.checked_in_on %>
+        <% if check_in.notes.present? %>
+          - <%= check_in.notes %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>No check-in history yet.</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root "home#index"
 
-  resources :profiles, only: [:new, :create] do
+  resources :profiles do
     resources :check_ins, only: [:index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,7 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  root "home#index"
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  resources :profiles, only: [:new, :create] do
+    resources :check_ins, only: [:index]
+  end
 end

--- a/db/migrate/20260318015933_create_profiles.rb
+++ b/db/migrate/20260318015933_create_profiles.rb
@@ -1,0 +1,10 @@
+class CreateProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :profiles do |t|
+      t.string :display_name
+      t.string :default_unit, default: 'in'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260320195022_create_check_in.rb
+++ b/db/migrate/20260320195022_create_check_in.rb
@@ -1,0 +1,11 @@
+class CreateCheckIn < ActiveRecord::Migration[7.1]
+  def change
+    create_table :check_ins do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.date :checked_in_on
+      t.text :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_18_015933) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_20_195022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "check_ins", force: :cascade do |t|
+    t.bigint "profile_id", null: false
+    t.date "checked_in_on"
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_check_ins_on_profile_id"
+  end
 
   create_table "profiles", force: :cascade do |t|
     t.string "display_name"
@@ -21,4 +30,5 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_18_015933) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "check_ins", "profiles"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2026_03_18_015933) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "profiles", force: :cascade do |t|
+    t.string "display_name"
+    t.string "default_unit", default: "in"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/features/profile/profile_crud_spec.rb
+++ b/spec/features/profile/profile_crud_spec.rb
@@ -1,0 +1,148 @@
+require 'rails_helper'
+
+RSpec.describe "Profile", type: :feature do
+    describe "CRUD Functionality" do
+        it "can create new profiles" do
+            visit "/profiles/new"
+            expect(current_path).to eq("/profiles/new")
+
+            fill_in "Display name", with: "John-Patrick"
+            select "Inches", from: "Default unit"
+
+            click_button "Create Profile"
+
+            profile_id = Profile.last.id
+            expect(current_path).to eq("/profiles/#{profile_id}")
+            # expect(page).to have_content("Profile created successfully")
+            expect(page).to have_content("John-Patrick")
+        end
+
+        it "can read a single profile/profile show" do
+            Profile.create!(display_name: "Pauly Do Little", default_unit: "in")
+            visit "/profiles/#{Profile.last.id}"
+            expect(page).to have_content("Pauly Do Little")
+            expect(page).to have_content("No check-in history yet.")
+        end
+
+        it "can read multiple profiles/profile index" do
+            Profile.create!(display_name: "Pauly Do Lottle", default_unit: "in")
+            Profile.create!(display_name: "Hope Johnstein", default_unit: "in")
+            Profile.create!(display_name: "John Hopenstein", default_unit: "in")
+            Profile.create!(display_name: "Harry Buttler", default_unit: "in")
+
+            visit "/profiles"
+            expect(page).to have_content("Pauly Do Lottle")
+            expect(page).to have_content("Hope Johnstein")
+            expect(page).to have_content("John Hopenstein")
+            expect(page).to have_content("Harry Buttler")
+        end
+
+        it "can update a profile" do
+            profile_1 = Profile.create!(display_name: "Pauly Do Lottle", default_unit: "in")
+
+            visit "profiles/#{profile_1.id}"
+            expect(current_path).to eq("/profiles/#{profile_1.id}")
+            expect(page).to have_content("Pauly Do Lottle")
+
+            click_link "Edit Profile"
+            expect(current_path).to eq("/profiles/#{profile_1.id}/edit")
+            fill_in "Display name", with: "Pauly Pocket"
+            click_button "Update Profile"
+
+            expect(current_path).to eq("/profiles/#{profile_1.id}")
+            expect(page).to have_content("Pauly Pocket")
+        end
+
+        it "can destroy a profile" do
+            profile_1 = Profile.create!(display_name: "Pauly Do Lottle", default_unit: "in")
+            profile_2 = Profile.create!(display_name: "Harry Buttler", default_unit: "in")
+
+            expect(Profile.all.count).to eq(2)
+            visit "profiles" 
+            expect(page).to have_content("Pauly Do Lottle")
+            expect(page).to have_content("Harry Buttler")
+
+            visit "profiles/#{profile_1.id}" 
+            click_button "Delete Profile"
+            expect(Profile.all.count).to eq(1)
+            expect(page).to have_content("Harry Buttler")
+            expect(page).not_to have_content("Pauly Do Lottle")
+        end
+    end
+
+    describe "Profile CRUD sad paths/edge cases" do
+        it "new profile with no display_name" do
+            visit "/profiles/new"
+            expect(current_path).to eq("/profiles/new")
+
+            fill_in "Display name", with: ""
+            select "Inches", from: "Default unit"
+
+            click_button "Create Profile"
+            expect(page).to have_content("Display name can't be blank")
+            expect(page).to have_content("Display name is too short (minimum is 2 characters)")
+        end
+
+        it "visit show page of non-existant profile" do
+            missing_id = Profile.maximum(:id).to_i + 1
+            visit "/profiles/#{missing_id}"
+            expect(page).to have_content("Profile not found")
+        end
+
+        it "new profile with display_name too short" do
+            visit "/profiles/new"
+          
+            fill_in "Display name", with: "J"
+            select "Inches", from: "Default unit"
+            click_button "Create Profile"
+          
+            expect(page).to have_content("Display name is too short")
+        end
+
+        it "new profile with display_name too long" do
+            visit "/profiles/new"
+          
+            fill_in "Display name", with: "J" * 51
+            select "Inches", from: "Default unit"
+            click_button "Create Profile"
+          
+            expect(page).to have_content("Display name is too long")
+        end
+
+        it "cannot update a profile with invalid data" do
+            profile = Profile.create!(display_name: "John", default_unit: "in")
+          
+            visit edit_profile_path(profile)
+          
+            fill_in "Display name", with: ""
+            select "Inches", from: "Default unit"
+            click_button "Update Profile"
+          
+            expect(page).to have_content("Display name can't be blank")
+            expect(profile.reload.display_name).to eq("John")
+        end
+
+        it "visit edit page of non-existent profile" do
+            visit "/profiles/999999/edit"
+          
+            expect(current_path).to eq("/profiles")
+            expect(page).to have_content("Profile not found.")
+        end
+
+        it "shows an empty state when there are no profiles" do
+            Profile.destroy_all
+          
+            visit "/profiles"
+          
+            expect(page).to have_content("No profiles yet.")
+        end
+
+        it "shows no check-ins message on profile show page" do
+            profile = Profile.create!(display_name: "John", default_unit: "in")
+          
+            visit profile_path(profile)
+          
+            expect(page).to have_content("No check-in history yet.")
+        end
+    end
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Profile, type: :model do
+    subject(:profile) {described_class.new(display_name: "Paul", default_unit: "in")}
+
+    it "has valid attributes" do
+        expect(profile).to be_valid
+    end
+
+    it "is invalid without a display_name" do
+        profile.display_name = nil
+        expect(profile).not_to be_valid
+    end
+
+    it "has a default unit" do
+        profile.default_unit = nil
+        expect(profile).not_to be_valid
+    end
+
+    it "is invalid with an unsupported default_unit" do
+        profile.default_unit = "lbs"
+        expect(profile).not_to be_valid
+    end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,7 +75,7 @@ RSpec.configure do |config|
   end
 
   Shoulda::Matchers.configure do |config|
-    config.intefrate do |with|
+    config.integrate do |with|
       with.test_framework :rspec
       with.library :rails
     end

--- a/spec/requests/check_ins_spec.rb
+++ b/spec/requests/check_ins_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "CheckIns", type: :request do
+  describe "GET /profiles/:profile_id/check_ins" do
+    it "returns http success" do
+      profile = Profile.create!(display_name: "Paul", default_unit: "in")
+
+      get profile_check_ins_path(profile)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe "Home", type: :request do
+    it "loads the home page" do
+        get"/"
+        expect(response).to have_http_status(:ok)
+    end
+end

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Profiles", type: :request do
+  describe "GET /profiles/new" do
+    it "returns a success response" do
+      get new_profile_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /profiles" do
+    context "with valid params" do
+      it "creates a profile and redirects to check-ins index" do
+        expect {
+          post profiles_path, params: {
+            profile: {
+              display_name: "Paul",
+              default_unit: "in"
+            }
+          }
+        }.to change(Profile, :count).by(1)
+
+        profile = Profile.last
+        expect(response).to redirect_to(profile_check_ins_path(profile))
+      end
+    end
+
+    context "with invalid params" do
+      it "does not create a profile" do
+        expect {
+          post profiles_path, params: {
+            profile: {
+              display_name: "",
+              default_unit: ""
+            }
+          }
+        }.not_to change(Profile, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Profiles", type: :request do
         }.to change(Profile, :count).by(1)
 
         profile = Profile.last
-        expect(response).to redirect_to(profile_check_ins_path(profile))
+        expect(response).to redirect_to(profile_path(profile))
       end
     end
 
@@ -38,6 +38,17 @@ RSpec.describe "Profiles", type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
+    end
+  end
+
+  describe "DELETE /profiles" do
+    it "redirects when deleting a non-existent profile" do
+      delete "/profiles/999999"
+
+      expect(response).to redirect_to(profiles_path)
+      follow_redirect!
+
+      expect(response.body).to include("Profile not found.")
     end
   end
 end


### PR DESCRIPTION
## Summary
This PR introduces full CRUD functionality for `Profile` along with comprehensive test coverage using **RSpec and Capybara**.

Profiles serve as the primary container for a user's fitness tracking data and will later own `CheckIns`, which track progress over time.

This implementation establishes the foundation for the upcoming **CheckIn tracking system**, which will be nested under profiles.

---

# Features Added

## Profile CRUD
The following CRUD operations were implemented for `Profile`.

### Create
Users can create a new profile containing:

- `display_name`
- `default_unit` (inches or centimeters)

Successful creation redirects to the profile show page.

Validation errors render inline error messages.

---

### Read

#### Profile Index
Users can view all profiles at: `/profiles`

The index page displays:

- Profile display name
- Default measurement unit
- Links to individual profiles
- Link to create a new profile

An empty state message is displayed when no profiles exist.

---

#### Profile Show
Each profile has a dedicated page displaying:

- Profile display name
- Default measurement unit
- Associated check-ins (placeholder for upcoming functionality)

If no check-ins exist, an empty state message is displayed.

---

### Update
Profiles can be edited via: `/profiles/:id/edit`

Users can modify:

- display name
- default unit

Successful updates redirect back to the profile show page.

Validation errors render the form again with error messages.

---

### Delete
Profiles can be deleted from the show page.

Deleting a profile:

- removes the profile
- redirects to the profiles index
- displays a confirmation message

Associated check-ins will cascade-delete via:

```ruby
has_many :check_ins, dependent: :destroy
```
