### PR TITLE
Implement Measurement Tracking

### DIFF
--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -8,59 +8,60 @@ class MeasurementsController < ApplicationController
     end
   
     def show
+        @measurements = @check_in.measurements
     end
   
     def new
-      @measurement = @check_in.measurements.new
+        @measurement = @check_in.measurements.new
     end
   
     def create
-      @measurement = @check_in.measurements.new(measurement_params)
-  
-      if @measurement.save
-        redirect_to profile_check_in_measurement_path(@profile, @check_in, @measurement), notice: "Measurement created successfully."
-      else
-        render :new, status: :unprocessable_content
-      end
+        @measurement = @check_in.measurements.new(measurement_params)
+    
+        if @measurement.save
+            redirect_to profile_check_in_measurement_path(@profile, @check_in, @measurement), notice: "Measurement created successfully."
+        else
+            render :new, status: :unprocessable_content
+        end
     end
   
     def edit
     end
   
     def update
-      if @measurement.update(measurement_params)
-        redirect_to profile_check_in_measurement_path(@profile, @check_in, @measurement), notice: "Measurement updated successfully."
-      else
-        render :edit, status: :unprocessable_content
-      end
+        if @measurement.update(measurement_params)
+            redirect_to profile_check_in_measurement_path(@profile, @check_in, @measurement), notice: "Measurement updated successfully."
+        else
+            render :edit, status: :unprocessable_content
+        end
     end
   
     def destroy
-      @measurement.destroy
-      redirect_to profile_check_in_measurements_path(@profile, @check_in), notice: "Measurement deleted successfully."
+        @measurement.destroy
+        redirect_to profile_check_in_measurements_path(@profile, @check_in), notice: "Measurement deleted successfully."
     end
   
     private
   
     def set_profile
-      @profile = Profile.find(params[:profile_id])
+        @profile = Profile.find(params[:profile_id])
     rescue ActiveRecord::RecordNotFound
-      redirect_to profiles_path, alert: "Profile not found."
+        redirect_to profiles_path, alert: "Profile not found."
     end
   
     def set_check_in
-      @check_in = @profile.check_ins.find(params[:check_in_id])
+        @check_in = @profile.check_ins.find(params[:check_in_id])
     rescue ActiveRecord::RecordNotFound
-      redirect_to profile_check_ins_path(@profile), alert: "Check-in not found."
+        redirect_to profile_check_ins_path(@profile), alert: "Check-in not found."
     end
   
     def set_measurement
-      @measurement = @check_in.measurements.find(params[:id])
+        @measurement = @check_in.measurements.find(params[:id])
     rescue ActiveRecord::RecordNotFound
-      redirect_to profile_check_in_measurements_path(@profile, @check_in), alert: "Measurement not found."
+        redirect_to profile_check_in_measurements_path(@profile, @check_in), alert: "Measurement not found."
     end
   
     def measurement_params
-      params.require(:measurement).permit(:body_part, :value)
+        params.require(:measurement).permit(:body_part, :value)
     end
   end

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -1,0 +1,66 @@
+class MeasurementsController < ApplicationController
+    before_action :set_profile
+    before_action :set_check_in
+    before_action :set_measurement, only: [:show, :edit, :update, :destroy]
+  
+    def index
+      @measurements = @check_in.measurements.order(:body_part)
+    end
+  
+    def show
+    end
+  
+    def new
+      @measurement = @check_in.measurements.new
+    end
+  
+    def create
+      @measurement = @check_in.measurements.new(measurement_params)
+  
+      if @measurement.save
+        redirect_to profile_check_in_measurement_path(@profile, @check_in, @measurement), notice: "Measurement created successfully."
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+  
+    def edit
+    end
+  
+    def update
+      if @measurement.update(measurement_params)
+        redirect_to profile_check_in_measurement_path(@profile, @check_in, @measurement), notice: "Measurement updated successfully."
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+  
+    def destroy
+      @measurement.destroy
+      redirect_to profile_check_in_measurements_path(@profile, @check_in), notice: "Measurement deleted successfully."
+    end
+  
+    private
+  
+    def set_profile
+      @profile = Profile.find(params[:profile_id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to profiles_path, alert: "Profile not found."
+    end
+  
+    def set_check_in
+      @check_in = @profile.check_ins.find(params[:check_in_id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to profile_check_ins_path(@profile), alert: "Check-in not found."
+    end
+  
+    def set_measurement
+      @measurement = @check_in.measurements.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to profile_check_in_measurements_path(@profile, @check_in), alert: "Measurement not found."
+    end
+  
+    def measurement_params
+      params.require(:measurement).permit(:body_part, :value)
+    end
+  end

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -8,7 +8,7 @@ class MeasurementsController < ApplicationController
     end
   
     def show
-        @measurements = @check_in.measurements
+        @measurements = @check_in.measurements.order(:body_part)
     end
   
     def new

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,7 +16,6 @@ class ProfilesController < ApplicationController
   end
 
   def show
-    # @profile = Profile.find(params[:id])
     @check_ins = @profile.check_ins.order(checked_in_on: :desc)
   end
 

--- a/app/models/check_in.rb
+++ b/app/models/check_in.rb
@@ -1,5 +1,6 @@
 class CheckIn < ApplicationRecord
     belongs_to :profile
+    has_many :measurements, dependent: :destroy
 
     validates :checked_in_on, presence: true, uniqueness: { scope: :profile_id }
     validate :checked_in_on_cannot_be_in_the_future

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -1,0 +1,18 @@
+class Measurement < ApplicationRecord
+  BODY_PARTS = %w[
+    weight
+    chest
+    waist
+    hips
+    shoulders
+    bicep_left
+    bicep_right
+    thigh_left
+    thigh_right
+  ].freeze
+
+  belongs_to :check_in
+
+  validates :body_part, presence: true, inclusion: { in: BODY_PARTS }
+  validates :value, presence: true, numericality: { greater_than: 0 }
+end

--- a/app/views/check_ins/show.html.erb
+++ b/app/views/check_ins/show.html.erb
@@ -19,3 +19,8 @@
 <p>
   <%= button_to "Delete Check-in", profile_check_in_path(@profile, @check_in), method: :delete %>
 </p>
+
+<p>
+  <%= link_to "View Measurements", profile_check_in_measurements_path(@profile, @check_in) %> |
+  <%= link_to "New Measurement", new_profile_check_in_measurement_path(@profile, @check_in) %>
+</p>

--- a/app/views/check_ins/show.html.erb
+++ b/app/views/check_ins/show.html.erb
@@ -16,11 +16,28 @@
   <%= link_to "Edit Check-in", edit_profile_check_in_path(@profile, @check_in) %>
 </p>
 
-<p>
-  <%= button_to "Delete Check-in", profile_check_in_path(@profile, @check_in), method: :delete %>
-</p>
+<hr>
+
+<h2>Measurements</h2>
 
 <p>
-  <%= link_to "View Measurements", profile_check_in_measurements_path(@profile, @check_in) %> |
-  <%= link_to "New Measurement", new_profile_check_in_measurement_path(@profile, @check_in) %>
+  <%= link_to "Add Measurement", new_profile_check_in_measurement_path(@profile, @check_in) %> |
+  <%= link_to "View All Measurements", profile_check_in_measurements_path(@profile, @check_in) %>
+</p>
+
+<% if @check_in.measurements.any? %>
+  <ul>
+    <% @check_in.measurements.order(:body_part).each do |measurement| %>
+      <li>
+        <%= link_to measurement.body_part.humanize, profile_check_in_measurement_path(@profile, @check_in, measurement) %>
+        : <%= measurement.value %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>No measurements yet.</p>
+<% end %>
+
+<p>
+  <%= button_to "Delete Check-in", profile_check_in_path(@profile, @check_in), method: :delete %>
 </p>

--- a/app/views/measurements/_form.html.erb
+++ b/app/views/measurements/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with model: [@profile, @check_in, @measurement] do |form| %>
+  <% if @measurement.errors.any? %>
+    <div>
+      <h2><%= pluralize(@measurement.errors.count, "error") %> prevented this measurement from being saved:</h2>
+      <ul>
+        <% @measurement.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :body_part %>
+    <%= form.select :body_part,
+        Measurement::BODY_PARTS.map { |body_part| [body_part.humanize, body_part] },
+        prompt: "Select a body part" %>
+  </div>
+
+  <div>
+    <%= form.label :value %>
+    <%= form.number_field :value, step: :any %>
+  </div>
+
+  <div>
+    <%= form.submit @measurement.persisted? ? "Update Measurement" : "Create Measurement" %>
+  </div>
+<% end %>

--- a/app/views/measurements/edit.html.erb
+++ b/app/views/measurements/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>Edit Measurement for <%= @check_in.formatted_date %></h1>
+
+<p>
+  <%= link_to "Back to Measurements", profile_check_in_measurements_path(@profile, @check_in) %> |
+  <%= link_to "Back to Check-in", profile_check_in_path(@profile, @check_in) %>
+</p>
+
+<%= render "form" %>

--- a/app/views/measurements/index.html.erb
+++ b/app/views/measurements/index.html.erb
@@ -1,0 +1,19 @@
+<h1>Measurements for <%= @check_in.formatted_date %></h1>
+
+<p>
+  <%= link_to "Back to Check-in", profile_check_in_path(@profile, @check_in) %> |
+  <%= link_to "New Measurement", new_profile_check_in_measurement_path(@profile, @check_in) %>
+</p>
+
+<% if @measurements.any? %>
+  <ul>
+    <% @measurements.each do |measurement| %>
+      <li>
+        <%= link_to measurement.body_part.humanize, profile_check_in_measurement_path(@profile, @check_in, measurement) %>
+        - <%= measurement.value %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>No measurements yet.</p>
+<% end %>

--- a/app/views/measurements/new.html.erb
+++ b/app/views/measurements/new.html.erb
@@ -1,0 +1,8 @@
+<h1>New Measurement for <%= @check_in.formatted_date %></h1>
+
+<p>
+  <%= link_to "Back to Measurements", profile_check_in_measurements_path(@profile, @check_in) %> |
+  <%= link_to "Back to Check-in", profile_check_in_path(@profile, @check_in) %>
+</p>
+
+<%= render "form" %>

--- a/app/views/measurements/show.html.erb
+++ b/app/views/measurements/show.html.erb
@@ -1,0 +1,17 @@
+<h1>Measurement for <%= @check_in.formatted_date %></h1>
+
+<p>
+  <strong>Body part:</strong>
+  <%= @measurement.body_part.humanize %>
+</p>
+
+<p>
+  <strong>Value:</strong>
+  <%= @measurement.value %>
+</p>
+
+<p>
+  <%= link_to "Back to Measurements", profile_check_in_measurements_path(@profile, @check_in) %> |
+  <%= link_to "Back to Check-in", profile_check_in_path(@profile, @check_in) %> |
+  <%= link_to "Edit Measurement", edit_profile_check_in_measurement_path(@profile, @check_in, @measurement) %>
+</p>

--- a/app/views/measurements/show.html.erb
+++ b/app/views/measurements/show.html.erb
@@ -15,3 +15,9 @@
   <%= link_to "Back to Check-in", profile_check_in_path(@profile, @check_in) %> |
   <%= link_to "Edit Measurement", edit_profile_check_in_measurement_path(@profile, @check_in, @measurement) %>
 </p>
+
+<p>
+  <%= button_to "Delete Measurement",
+      profile_check_in_measurement_path(@profile, @check_in, @measurement),
+      method: :delete %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   root "home#index"
 
   resources :profiles do
-    resources :check_ins
+    resources :check_ins do
+      resources :measurements
+    end
   end
 end

--- a/db/migrate/20260405192643_create_measurements.rb
+++ b/db/migrate/20260405192643_create_measurements.rb
@@ -1,0 +1,11 @@
+class CreateMeasurements < ActiveRecord::Migration[7.1]
+  def change
+    create_table :measurements do |t|
+      t.references :check_in, null: false, foreign_key: true
+      t.string :body_part
+      t.decimal :value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_03_164624) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_05_192643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_03_164624) do
     t.index ["profile_id"], name: "index_check_ins_on_profile_id"
   end
 
+  create_table "measurements", force: :cascade do |t|
+    t.bigint "check_in_id", null: false
+    t.string "body_part"
+    t.decimal "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["check_in_id"], name: "index_measurements_on_check_in_id"
+  end
+
   create_table "profiles", force: :cascade do |t|
     t.string "display_name"
     t.string "default_unit", default: "in"
@@ -32,4 +41,5 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_03_164624) do
   end
 
   add_foreign_key "check_ins", "profiles"
+  add_foreign_key "measurements", "check_ins"
 end

--- a/spec/features/check_in/check_in_crud_spec.rb
+++ b/spec/features/check_in/check_in_crud_spec.rb
@@ -80,6 +80,30 @@ RSpec.describe "CheckIn", type: :feature do
             expect(page).to have_content("Check-in deleted successfully.")
             expect(CheckIn.exists?(check_in.id)).to be(false)
         end
+
+        it "shows a check-in's measurements on the check-in show page" do
+            profile = Profile.create!(display_name: "Paul", default_unit: "in")
+            check_in = profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update")
+            check_in.measurements.create!(body_part: "waist", value: 34.5)
+            check_in.measurements.create!(body_part: "chest", value: 42.0)
+            
+            visit profile_check_in_path(profile, check_in)
+            
+            expect(page).to have_content("Measurements")
+            expect(page).to have_content("Waist")
+            expect(page).to have_content("34.5")
+            expect(page).to have_content("Chest")
+            expect(page).to have_content("42.0")
+        end
+
+        it "shows an empty state when a check-in has no measurements" do
+            profile = Profile.create!(display_name: "Paul", default_unit: "in")
+            check_in = profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update")
+            
+            visit profile_check_in_path(profile, check_in)
+            
+            expect(page).to have_content("No measurements yet.")
+        end
     end
 
     describe "sad paths / edge cases" do

--- a/spec/features/measurements/measurement_crud_spec.rb
+++ b/spec/features/measurements/measurement_crud_spec.rb
@@ -6,39 +6,77 @@ RSpec.describe "Measurement", type: :feature do
     let!(:check_in) { profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update") }
 
     it "can read multiple measurements" do
-      measurement_1 = check_in.measurements.create!(body_part: "waist", value: 34.5)
-      measurement_2 = check_in.measurements.create!(body_part: "chest", value: 42.0)
+        measurement_1 = check_in.measurements.create!(body_part: "waist", value: 34.5)
+        measurement_2 = check_in.measurements.create!(body_part: "chest", value: 42.0)
 
-      visit profile_check_in_measurements_path(profile, check_in)
+        visit profile_check_in_measurements_path(profile, check_in)
 
-      expect(page).to have_content("Measurements for #{check_in.formatted_date}")
-      expect(page).to have_content(measurement_1.body_part.humanize)
-      expect(page).to have_content(measurement_1.value)
-      expect(page).to have_content(measurement_2.body_part.humanize)
-      expect(page).to have_content(measurement_2.value)
+        expect(page).to have_content("Measurements for #{check_in.formatted_date}")
+        expect(page).to have_content(measurement_1.body_part.humanize)
+        expect(page).to have_content(measurement_1.value)
+        expect(page).to have_content(measurement_2.body_part.humanize)
+        expect(page).to have_content(measurement_2.value)
     end
 
     it "can visit the new measurement page" do
-      visit new_profile_check_in_measurement_path(profile, check_in)
+        visit new_profile_check_in_measurement_path(profile, check_in)
 
-      expect(page).to have_content("New Measurement for #{check_in.formatted_date}")
-      expect(page).to have_select("Body part", options: ["Select a body part"] + Measurement::BODY_PARTS.map(&:humanize))
-      expect(page).to have_field("Value")
+        expect(page).to have_content("New Measurement for #{check_in.formatted_date}")
+        expect(page).to have_select("Body part", options: ["Select a body part"] + Measurement::BODY_PARTS.map(&:humanize))
+        expect(page).to have_field("Value")
     end
 
     it "can create a new measurement" do
-      visit new_profile_check_in_measurement_path(profile, check_in)
+        visit new_profile_check_in_measurement_path(profile, check_in)
 
-      select "Waist", from: "Body part"
-      fill_in "Value", with: 34.5
-      click_button "Create Measurement"
+        select "Waist", from: "Body part"
+        fill_in "Value", with: 34.5
+        click_button "Create Measurement"
 
-      measurement = Measurement.last
+        measurement = Measurement.last
 
-      expect(current_path).to eq(profile_check_in_measurement_path(profile, check_in, measurement))
-      expect(page).to have_content("Measurement created successfully.")
-      expect(page).to have_content("Waist")
-      expect(page).to have_content("34.5")
+        expect(current_path).to eq(profile_check_in_measurement_path(profile, check_in, measurement))
+        expect(page).to have_content("Measurement created successfully.")
+        expect(page).to have_content("Waist")
+        expect(page).to have_content("34.5")
+    end
+
+    it "can read a single measurement" do
+        measurement = check_in.measurements.create!(body_part: "waist", value: 34.5)
+
+        visit profile_check_in_measurement_path(profile, check_in, measurement)
+
+        expect(page).to have_content("Measurement for #{check_in.formatted_date}")
+        expect(page).to have_content("Waist")
+        expect(page).to have_content("34.5")
+    end
+
+    it "can update a measurement" do
+        measurement = check_in.measurements.create!(body_part: "waist", value: 34.5)
+
+        visit edit_profile_check_in_measurement_path(profile, check_in, measurement)
+
+        select "Chest", from: "Body part"
+        fill_in "Value", with: 42.0
+        click_button "Update Measurement"
+
+        expect(current_path).to eq(profile_check_in_measurement_path(profile, check_in, measurement))
+        expect(page).to have_content("Measurement updated successfully.")
+        expect(page).to have_content("Chest")
+        expect(page).to have_content("42.0")
+        expect(measurement.reload.body_part).to eq("chest")
+        expect(measurement.reload.value.to_f).to eq(42.0)
+    end
+
+    it "can destroy a measurement" do
+        measurement = check_in.measurements.create!(body_part: "waist", value: 34.5)
+
+        visit profile_check_in_measurement_path(profile, check_in, measurement)
+        click_button "Delete Measurement"
+
+        expect(current_path).to eq(profile_check_in_measurements_path(profile, check_in))
+        expect(page).to have_content("Measurement deleted successfully.")
+        expect(Measurement.exists?(measurement.id)).to be(false)
     end
   end
 
@@ -47,27 +85,54 @@ RSpec.describe "Measurement", type: :feature do
     let!(:check_in) { profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update") }
 
     it "cannot create a measurement without a body part" do
-      visit new_profile_check_in_measurement_path(profile, check_in)
+        visit new_profile_check_in_measurement_path(profile, check_in)
 
-      fill_in "Value", with: 34.5
-      click_button "Create Measurement"
+        fill_in "Value", with: 34.5
+        click_button "Create Measurement"
 
-      expect(page).to have_content("Body part can't be blank")
+        expect(page).to have_content("Body part can't be blank")
     end
 
     it "cannot create a measurement without a value" do
-      visit new_profile_check_in_measurement_path(profile, check_in)
+        visit new_profile_check_in_measurement_path(profile, check_in)
 
-      select "Waist", from: "Body part"
-      click_button "Create Measurement"
+        select "Waist", from: "Body part"
+        click_button "Create Measurement"
 
-      expect(page).to have_content("Value can't be blank")
+        expect(page).to have_content("Value can't be blank")
+    end
+
+    it "cannot update a measurement with invalid data" do
+        measurement = check_in.measurements.create!(body_part: "waist", value: 34.5)
+
+        visit edit_profile_check_in_measurement_path(profile, check_in, measurement)
+
+        select "Waist", from: "Body part"
+        fill_in "Value", with: ""
+        click_button "Update Measurement"
+
+        expect(page).to have_content("Value can't be blank")
+        expect(measurement.reload.value.to_f).to eq(34.5)
     end
 
     it "shows an empty state when a check-in has no measurements" do
-      visit profile_check_in_measurements_path(profile, check_in)
+        visit profile_check_in_measurements_path(profile, check_in)
 
-      expect(page).to have_content("No measurements yet.")
+        expect(page).to have_content("No measurements yet.")
+    end
+
+    it "redirects when visiting the show page of a non-existent measurement" do
+        visit "/profiles/#{profile.id}/check_ins/#{check_in.id}/measurements/999999"
+
+        expect(current_path).to eq(profile_check_in_measurements_path(profile, check_in))
+        expect(page).to have_content("Measurement not found.")
+    end
+
+    it "redirects when visiting the edit page of a non-existent measurement" do
+        visit "/profiles/#{profile.id}/check_ins/#{check_in.id}/measurements/999999/edit"
+
+        expect(current_path).to eq(profile_check_in_measurements_path(profile, check_in))
+        expect(page).to have_content("Measurement not found.")
     end
   end
 end

--- a/spec/features/measurements/measurement_crud_spec.rb
+++ b/spec/features/measurements/measurement_crud_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe "Measurement", type: :feature do
+  describe "CRUD Functionality" do
+    let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+    let!(:check_in) { profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update") }
+
+    it "can read multiple measurements" do
+      measurement_1 = check_in.measurements.create!(body_part: "waist", value: 34.5)
+      measurement_2 = check_in.measurements.create!(body_part: "chest", value: 42.0)
+
+      visit profile_check_in_measurements_path(profile, check_in)
+
+      expect(page).to have_content("Measurements for #{check_in.formatted_date}")
+      expect(page).to have_content(measurement_1.body_part.humanize)
+      expect(page).to have_content(measurement_1.value)
+      expect(page).to have_content(measurement_2.body_part.humanize)
+      expect(page).to have_content(measurement_2.value)
+    end
+
+    it "can visit the new measurement page" do
+      visit new_profile_check_in_measurement_path(profile, check_in)
+
+      expect(page).to have_content("New Measurement for #{check_in.formatted_date}")
+      expect(page).to have_select("Body part", options: ["Select a body part"] + Measurement::BODY_PARTS.map(&:humanize))
+      expect(page).to have_field("Value")
+    end
+
+    it "can create a new measurement" do
+      visit new_profile_check_in_measurement_path(profile, check_in)
+
+      select "Waist", from: "Body part"
+      fill_in "Value", with: 34.5
+      click_button "Create Measurement"
+
+      measurement = Measurement.last
+
+      expect(current_path).to eq(profile_check_in_measurement_path(profile, check_in, measurement))
+      expect(page).to have_content("Measurement created successfully.")
+      expect(page).to have_content("Waist")
+      expect(page).to have_content("34.5")
+    end
+  end
+
+  describe "sad paths / edge cases" do
+    let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+    let!(:check_in) { profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update") }
+
+    it "cannot create a measurement without a body part" do
+      visit new_profile_check_in_measurement_path(profile, check_in)
+
+      fill_in "Value", with: 34.5
+      click_button "Create Measurement"
+
+      expect(page).to have_content("Body part can't be blank")
+    end
+
+    it "cannot create a measurement without a value" do
+      visit new_profile_check_in_measurement_path(profile, check_in)
+
+      select "Waist", from: "Body part"
+      click_button "Create Measurement"
+
+      expect(page).to have_content("Value can't be blank")
+    end
+
+    it "shows an empty state when a check-in has no measurements" do
+      visit profile_check_in_measurements_path(profile, check_in)
+
+      expect(page).to have_content("No measurements yet.")
+    end
+  end
+end

--- a/spec/models/measurement_spec.rb
+++ b/spec/models/measurement_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Measurement, type: :model do
+  let(:profile) do
+    Profile.create!(display_name: "JP", default_unit: "in")
+  end
+
+  let(:check_in) do
+    profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly Update")
+  end
+
+  subject(:measurement) do
+    described_class.new(
+      check_in: check_in,
+      body_part: "waist",
+      value: 34.5
+    )
+  end
+
+  describe "associations" do
+    it { should belong_to(:check_in) }
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(measurement).to be_valid
+    end
+
+    it "is invalid without a check_in" do
+      measurement.check_in = nil
+
+      expect(measurement).not_to be_valid
+      expect(measurement.errors[:check_in]).to include("must exist")
+    end
+
+    it "is invalid without a body_part" do
+      measurement.body_part = nil
+
+      expect(measurement).not_to be_valid
+      expect(measurement.errors[:body_part]).to include("can't be blank")
+    end
+
+    it "is invalid with an unsupported body_part" do
+      measurement.body_part = "forearm"
+
+      expect(measurement).not_to be_valid
+      expect(measurement.errors[:body_part]).to include("is not included in the list")
+    end
+
+    it "is valid for each allowed body part" do
+      Measurement::BODY_PARTS.each do |body_part|
+        measurement.body_part = body_part
+        expect(measurement).to be_valid
+      end
+    end
+
+    it "is invalid without a value" do
+      measurement.value = nil
+
+      expect(measurement).not_to be_valid
+      expect(measurement.errors[:value]).to include("can't be blank")
+    end
+
+    it "is invalid with a value of 0" do
+      measurement.value = 0
+
+      expect(measurement).not_to be_valid
+      expect(measurement.errors[:value]).to include("must be greater than 0")
+    end
+
+    it "is invalid with a negative value" do
+      measurement.value = -2
+
+      expect(measurement).not_to be_valid
+      expect(measurement.errors[:value]).to include("must be greater than 0")
+    end
+
+    it "is valid with a positive decimal value" do
+      measurement.value = 15.75
+
+      expect(measurement).to be_valid
+    end
+  end
+end

--- a/spec/requests/measurements_spec.rb
+++ b/spec/requests/measurements_spec.rb
@@ -65,4 +65,89 @@ RSpec.describe "Measurements", type: :request do
       end
     end
   end
+
+  describe "GET /profiles/:profile_id/check_ins/:check_in_id/measurements/:id" do
+    it "returns http success" do
+      measurement = check_in.measurements.create!(body_part: "waist", value: 34.5)
+
+      get profile_check_in_measurement_path(profile, check_in, measurement)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "redirects when the measurement does not exist" do
+      get "/profiles/#{profile.id}/check_ins/#{check_in.id}/measurements/999999"
+
+      expect(response).to redirect_to(profile_check_in_measurements_path(profile, check_in))
+    end
+  end
+
+  describe "GET /profiles/:profile_id/check_ins/:check_in_id/measurements/:id/edit" do
+    it "returns http success" do
+      measurement = check_in.measurements.create!(body_part: "waist", value: 34.5)
+
+      get edit_profile_check_in_measurement_path(profile, check_in, measurement)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "redirects when the measurement does not exist" do
+      get "/profiles/#{profile.id}/check_ins/#{check_in.id}/measurements/999999/edit"
+
+      expect(response).to redirect_to(profile_check_in_measurements_path(profile, check_in))
+    end
+  end
+
+  describe "PATCH /profiles/:profile_id/check_ins/:check_in_id/measurements/:id" do
+    let!(:measurement) do
+      check_in.measurements.create!(body_part: "waist", value: 34.5)
+    end
+
+    context "with valid params" do
+      it "updates the measurement and redirects to the show page" do
+        patch profile_check_in_measurement_path(profile, check_in, measurement), params: {
+          measurement: {
+            body_part: "chest",
+            value: 42.0
+          }
+        }
+
+        expect(response).to redirect_to(profile_check_in_measurement_path(profile, check_in, measurement))
+        expect(measurement.reload.body_part).to eq("chest")
+        expect(measurement.reload.value.to_f).to eq(42.0)
+      end
+    end
+
+    context "with invalid params" do
+      it "does not update the measurement with a blank value" do
+        patch profile_check_in_measurement_path(profile, check_in, measurement), params: {
+          measurement: {
+            body_part: "waist",
+            value: nil
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(measurement.reload.value.to_f).to eq(34.5)
+      end
+    end
+  end
+
+  describe "DELETE /profiles/:profile_id/check_ins/:check_in_id/measurements/:id" do
+    it "deletes the measurement and redirects to the index page" do
+      measurement = check_in.measurements.create!(body_part: "waist", value: 34.5)
+
+      expect {
+        delete profile_check_in_measurement_path(profile, check_in, measurement)
+      }.to change(Measurement, :count).by(-1)
+
+      expect(response).to redirect_to(profile_check_in_measurements_path(profile, check_in))
+    end
+
+    it "redirects when deleting a non-existent measurement" do
+      delete "/profiles/#{profile.id}/check_ins/#{check_in.id}/measurements/999999"
+
+      expect(response).to redirect_to(profile_check_in_measurements_path(profile, check_in))
+    end
+  end
 end

--- a/spec/requests/measurements_spec.rb
+++ b/spec/requests/measurements_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "Measurements", type: :request do
+  let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+  let!(:check_in) { profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update") }
+
+  describe "GET /profiles/:profile_id/check_ins/:check_in_id/measurements" do
+    it "returns http success" do
+      get profile_check_in_measurements_path(profile, check_in)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /profiles/:profile_id/check_ins/:check_in_id/measurements/new" do
+    it "returns http success" do
+      get new_profile_check_in_measurement_path(profile, check_in)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /profiles/:profile_id/check_ins/:check_in_id/measurements" do
+    context "with valid params" do
+      it "creates a measurement and redirects to the show page" do
+        expect {
+          post profile_check_in_measurements_path(profile, check_in), params: {
+            measurement: {
+              body_part: "waist",
+              value: 34.5
+            }
+          }
+        }.to change(Measurement, :count).by(1)
+
+        measurement = Measurement.last
+        expect(response).to redirect_to(profile_check_in_measurement_path(profile, check_in, measurement))
+      end
+    end
+
+    context "with invalid params" do
+      it "does not create a measurement without a body part" do
+        expect {
+          post profile_check_in_measurements_path(profile, check_in), params: {
+            measurement: {
+              body_part: "",
+              value: 34.5
+            }
+          }
+        }.not_to change(Measurement, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "does not create a measurement without a value" do
+        expect {
+          post profile_check_in_measurements_path(profile, check_in), params: {
+            measurement: {
+              body_part: "waist",
+              value: nil
+            }
+          }
+        }.not_to change(Measurement, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR introduces full CRUD functionality for Measurements, which allow users to record body measurements for a specific check-in.

Measurements represent structured fitness data such as waist, chest, biceps, or weight, and are associated with a specific CheckIn. This expands the application from simple check-in logging to actual progress tracking.

Measurements are nested under CheckIns, which themselves belong to Profiles.

Application structure:

Profile → CheckIn → Measurement

Features Added
Measurement CRUD

The following RESTful actions were implemented:
```
• Index — view all measurements for a check-in
• Show — view a single measurement
• New — create a new measurement
• Edit — update an existing measurement
• Destroy — delete a measurement
```
Routes are fully nested to preserve context:

/profiles/:profile_id/check_ins/:check_in_id/measurements

### Data Model

A new Measurement model was introduced.

Columns include:
```
• id
• check_in_id
• body_part
• value
• created_at
• updated_at
```
### Associations

Measurement belongs_to :check_in
CheckIn has_many :measurements, dependent: :destroy

This ensures measurements are removed automatically if their parent check-in is deleted.

### Validations

The Measurement model enforces the following constraints:
```
• body_part must be present
• body_part must be one of the allowed measurement types
• value must be present
• value must be greater than zero
```
Allowed body parts are defined in a constant within the model to centralize validation and form options.

Supported body parts:
```
• weight
• chest
• waist
• hips
• shoulders
• bicep_left
• bicep_right
• thigh_left
• thigh_right
```
### Controller

A new MeasurementsController was implemented with full RESTful functionality.

Controller behavior includes:

• nested record lookups through Profile and CheckIn
• graceful redirects for missing records
• validation error handling via form re-rendering
• flash messages for successful create/update/delete actions

### Views

Views were added for all measurement actions:
```sh
measurements/index
measurements/show
measurements/new
measurements/edit
```
A shared form partial was created:

measurements/_form

The form uses the model's BODY_PARTS constant to populate the body part dropdown.

## Testing

### Model Specs

Location:
`spec/models/measurement_spec.rb`

Tests verify:

• association with CheckIn
• body part inclusion validation
• presence validation
• numeric value validation

### Feature Specs

Location:
`spec/features/measurement/measurement_crud_spec.rb`

Feature tests simulate user interactions including:

• viewing measurements for a check-in
• creating a measurement
• editing a measurement
• deleting a measurement
• validation failures
• empty measurement states

### Request Specs

Location:
spec/requests/measurements_spec.rb

Request tests verify controller responses for:

• index
• show
• new
• create
• edit
• update
• destroy

Edge cases include invalid create/update requests and missing records.

## UX Improvements

Measurements are now accessible directly from the CheckIn context through nested navigation.

Users can navigate from:

Profile → CheckIn → Measurements

This maintains clear context for progress tracking.