### PR TITLE
Measurement constraints to restrict body_part to one of each per check_in

### DIFF
--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -15,6 +15,6 @@ class Measurement < ApplicationRecord
 
   has_one_attached :body_part_photo
 
-  validates :body_part, presence: true, inclusion: { in: BODY_PARTS }
+  validates :body_part, presence: true, inclusion: { in: BODY_PARTS }, uniqueness: { scope: :check_in_id }
   validates :value, presence: true, numericality: { greater_than: 0 }
 end

--- a/db/migrate/20260407211041_add_unique_index_to_measurements_on_check_in_and_body_part.rb
+++ b/db/migrate/20260407211041_add_unique_index_to_measurements_on_check_in_and_body_part.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToMeasurementsOnCheckInAndBodyPart < ActiveRecord::Migration[7.1]
+  def change
+    add_index :measurements, [:check_in_id, :body_part], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_06_172724) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_07_211041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_06_172724) do
     t.decimal "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["check_in_id", "body_part"], name: "index_measurements_on_check_in_id_and_body_part", unique: true
     t.index ["check_in_id"], name: "index_measurements_on_check_in_id"
   end
 

--- a/spec/models/measurement_spec.rb
+++ b/spec/models/measurement_spec.rb
@@ -80,5 +80,43 @@ RSpec.describe Measurement, type: :model do
 
       expect(measurement).to be_valid
     end
+
+    it "does not allow duplicate body parts for the same check_in" do
+      described_class.create!(
+        check_in: check_in,
+        body_part: "waist",
+        value: 34.5
+      )
+    
+      duplicate = described_class.new(
+        check_in: check_in,
+        body_part: "waist",
+        value: 35.0
+      )
+    
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:body_part]).to include("has already been taken")
+    end
+    
+    it "allows the same body part on different check_ins" do
+      other_check_in = profile.check_ins.create!(
+        checked_in_on: Date.current - 1.day,
+        notes: "Another check-in"
+      )
+    
+      described_class.create!(
+        check_in: check_in,
+        body_part: "waist",
+        value: 34.5
+      )
+    
+      measurement = described_class.new(
+        check_in: other_check_in,
+        body_part: "waist",
+        value: 35.0
+      )
+    
+      expect(measurement).to be_valid
+    end
   end
 end


### PR DESCRIPTION
### Summary
* Add model level validation
* Add db level validation to prevent db level saving faulty data