### PR TITLE
Add Profile Progress Reporting

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,22 @@
+class ReportsController < ApplicationController
+    before_action :set_profile
+  
+    def show
+      @body_part = params[:body_part].presence
+      @timeframe = params[:timeframe].presence || "all_time"
+  
+      @report = MeasurementReport.new(
+        profile: @profile,
+        body_part: @body_part,
+        timeframe: @timeframe
+      )
+    end
+  
+    private
+  
+    def set_profile
+      @profile = Profile.find(params[:profile_id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to profiles_path, alert: "Profile not found."
+    end
+end

--- a/app/services/measurement_report.rb
+++ b/app/services/measurement_report.rb
@@ -1,0 +1,84 @@
+class MeasurementReport
+    TIMEFRAME_OPTIONS = {
+      "30_days" => 30,
+      "90_days" => 90,
+      "6_months" => 180,
+      "1_year" => 365,
+      "all_time" => nil
+    }.freeze
+  
+    attr_reader :profile, :body_part, :timeframe
+  
+    def initialize(profile:, body_part:, timeframe: "all_time")
+      @profile = profile
+      @body_part = body_part
+      @timeframe = timeframe
+    end
+  
+    def measurements
+      @measurements ||= filtered_measurements.order("check_ins.checked_in_on ASC")
+    end
+  
+    def chart_data
+      measurements.map do |measurement|
+        {
+          date: measurement.check_in.checked_in_on,
+          value: measurement.value.to_f
+        }
+      end
+    end
+  
+    def summary
+      return empty_summary if measurements.empty?
+  
+      values = measurements.map { |measurement| measurement.value.to_f }
+  
+      {
+        body_part: body_part,
+        timeframe: timeframe,
+        count: measurements.count,
+        start_date: measurements.first.check_in.checked_in_on,
+        end_date: measurements.last.check_in.checked_in_on,
+        starting_value: values.first,
+        ending_value: values.last,
+        change: (values.last - values.first).round(2),
+        min: values.min,
+        max: values.max,
+        average: (values.sum / values.size).round(2)
+      }
+    end
+  
+    private
+  
+    def filtered_measurements
+        scope = Measurement
+            .includes(:check_in)
+            .joins(:check_in)
+            .where(check_ins: { profile_id: profile.id })
+            .where(body_part: body_part)
+        
+        days = TIMEFRAME_OPTIONS[timeframe]
+        
+        if days.present?
+            scope = scope.where("check_ins.checked_in_on >= ?", Date.current - days.days)
+        end
+        
+        scope
+    end
+  
+    def empty_summary
+      {
+        body_part: body_part,
+        timeframe: timeframe,
+        count: 0,
+        start_date: nil,
+        end_date: nil,
+        starting_value: nil,
+        ending_value: nil,
+        change: nil,
+        min: nil,
+        max: nil,
+        average: nil
+      }
+    end
+  end

--- a/app/services/measurement_report.rb
+++ b/app/services/measurement_report.rb
@@ -1,44 +1,94 @@
 class MeasurementReport
-    TIMEFRAME_OPTIONS = {
-      "30_days" => 30,
-      "90_days" => 90,
-      "6_months" => 180,
-      "1_year" => 365,
-      "all_time" => nil
-    }.freeze
-  
-    attr_reader :profile, :body_part, :timeframe
-  
-    def initialize(profile:, body_part:, timeframe: "all_time")
-      @profile = profile
-      @body_part = body_part
-      @timeframe = timeframe
-    end
-  
-    def measurements
-      @measurements ||= filtered_measurements.order("check_ins.checked_in_on ASC")
-    end
-  
-    def chart_data
-      measurements.map do |measurement|
-        {
-          date: measurement.check_in.checked_in_on,
-          value: measurement.value.to_f
-        }
-      end
-    end
-  
-    def summary
-      return empty_summary if measurements.empty?
-  
-      values = measurements.map { |measurement| measurement.value.to_f }
-  
+  TIMEFRAME_OPTIONS = {
+    "30_days" => 30,
+    "90_days" => 90,
+    "6_months" => 180,
+    "1_year" => 365,
+    "all_time" => nil
+  }.freeze
+
+  attr_reader :profile, :body_part, :timeframe
+
+  def initialize(profile:, body_part: nil, timeframe: "all_time")
+    @profile = profile
+    @body_part = body_part.presence
+    @timeframe = timeframe
+  end
+
+  def measurements
+    @measurements ||= filtered_measurements.order("check_ins.checked_in_on ASC, measurements.body_part ASC")
+  end
+
+  def chart_data
+    measurements.map do |measurement|
       {
-        body_part: body_part,
+        body_part: measurement.body_part,
+        date: measurement.check_in.checked_in_on,
+        value: measurement.value.to_f
+      }
+    end
+  end
+
+  def summary
+    return grouped_summary if body_part.blank?
+    single_body_part_summary
+  end
+
+  def measurements_grouped_by_body_part
+    measurements.group_by(&:body_part)
+  end
+
+  private
+
+  def filtered_measurements
+    scope = Measurement
+      .includes(:check_in)
+      .joins(:check_in)
+      .where(check_ins: { profile_id: profile.id })
+
+    scope = scope.where(body_part: body_part) if body_part.present?
+
+    days = TIMEFRAME_OPTIONS[timeframe]
+
+    if days.present?
+      scope = scope.where("check_ins.checked_in_on >= ?", Date.current - days.days)
+    end
+
+    scope
+  end
+
+  def single_body_part_summary
+    return empty_summary(body_part) if measurements.empty?
+
+    values = measurements.map { |measurement| measurement.value.to_f }
+
+    {
+      body_part: body_part,
+      timeframe: timeframe,
+      count: measurements.count,
+      start_date: measurements.first.check_in.checked_in_on,
+      end_date: measurements.last.check_in.checked_in_on,
+      starting_value: values.first,
+      ending_value: values.last,
+      change: (values.last - values.first).round(2),
+      min: values.min,
+      max: values.max,
+      average: (values.sum / values.size).round(2)
+    }
+  end
+
+  def grouped_summary
+    grouped = measurements.group_by(&:body_part)
+
+    grouped.transform_values do |body_part_measurements|
+      values = body_part_measurements.map { |measurement| measurement.value.to_f }
+
+      {
+        body_part: body_part_measurements.first.body_part,
         timeframe: timeframe,
-        count: measurements.count,
-        start_date: measurements.first.check_in.checked_in_on,
-        end_date: measurements.last.check_in.checked_in_on,
+        count: body_part_measurements.count,
+        start_date: body_part_measurements.first.check_in.checked_in_on,
+        end_date: body_part_measurements.last.check_in.checked_in_on,
         starting_value: values.first,
         ending_value: values.last,
         change: (values.last - values.first).round(2),
@@ -47,38 +97,21 @@ class MeasurementReport
         average: (values.sum / values.size).round(2)
       }
     end
-  
-    private
-  
-    def filtered_measurements
-        scope = Measurement
-            .includes(:check_in)
-            .joins(:check_in)
-            .where(check_ins: { profile_id: profile.id })
-            .where(body_part: body_part)
-        
-        days = TIMEFRAME_OPTIONS[timeframe]
-        
-        if days.present?
-            scope = scope.where("check_ins.checked_in_on >= ?", Date.current - days.days)
-        end
-        
-        scope
-    end
-  
-    def empty_summary
-      {
-        body_part: body_part,
-        timeframe: timeframe,
-        count: 0,
-        start_date: nil,
-        end_date: nil,
-        starting_value: nil,
-        ending_value: nil,
-        change: nil,
-        min: nil,
-        max: nil,
-        average: nil
-      }
-    end
   end
+
+  def empty_summary(selected_body_part)
+    {
+      body_part: selected_body_part,
+      timeframe: timeframe,
+      count: 0,
+      start_date: nil,
+      end_date: nil,
+      starting_value: nil,
+      ending_value: nil,
+      change: nil,
+      min: nil,
+      max: nil,
+      average: nil
+    }
+  end
+end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -5,6 +5,10 @@
   <%= @profile.formatted_default_unit %>
 </p>
 
+<p>
+  <%= link_to "View Progress Report", profile_report_path(@profile) %>
+</p>
+
 <div>
   <%= link_to "Edit Profile", edit_profile_path(@profile) %>
   <%= button_to "Delete Profile", profile_path(@profile), method: :delete, data: { turbo_confirm: "Are you sure?" } %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,89 @@
+<h1><%= @profile.display_name %> Progress Report</h1>
+
+<p>
+  <%= link_to "Back to Profile", profile_path(@profile) %>
+</p>
+
+<%= form_with url: profile_report_path(@profile), method: :get, local: true do |form| %>
+  <div>
+    <%= form.label :body_part, "Body Part" %>
+    <%= form.select :body_part,
+        options_for_select([["All Body Parts", ""]] + Measurement::BODY_PARTS.map { |body_part| [body_part.humanize, body_part] }, @body_part) %>
+  </div>
+
+  <div>
+    <%= form.label :timeframe, "Timeframe" %>
+    <%= form.select :timeframe,
+        options_for_select(MeasurementReport::TIMEFRAME_OPTIONS.keys.map { |option| [option.humanize, option] }, @timeframe) %>
+  </div>
+
+  <div>
+    <%= form.submit "Run Report" %>
+  </div>
+<% end %>
+
+<hr>
+
+<% if @body_part.present? %>
+    <% summary = @report.summary %>
+
+    <% if summary[:count] > 0 %>
+        <h2><%= summary[:body_part].humanize %></h2>
+
+        <p><strong>Timeframe:</strong> <%= summary[:timeframe].humanize %></p>
+        <p><strong>Entries:</strong> <%= summary[:count] %></p>
+        <p><strong>Start Date:</strong> <%= summary[:start_date] %></p>
+        <p><strong>End Date:</strong> <%= summary[:end_date] %></p>
+        <p><strong>Starting Value:</strong> <%= summary[:starting_value] %></p>
+        <p><strong>Ending Value:</strong> <%= summary[:ending_value] %></p>
+        <p><strong>Change:</strong> <%= summary[:change] %></p>
+        <p><strong>Minimum:</strong> <%= summary[:min] %></p>
+        <p><strong>Maximum:</strong> <%= summary[:max] %></p>
+        <p><strong>Average:</strong> <%= summary[:average] %></p>
+
+        <h3>History</h3>
+        <ul>
+        <% @report.measurements.each do |measurement| %>
+            <li>
+            <%= link_to measurement.check_in.formatted_date, profile_check_in_path(@profile, measurement.check_in) %>: <%= measurement.value %>
+            </li>
+        <% end %>
+        </ul>
+    <% else %>
+        <p>No measurements found for this body part.</p>
+    <% end %>
+<% else %>
+    <% grouped_summary = @report.summary %>
+
+    <% if grouped_summary.any? %>
+        <% Measurement::BODY_PARTS.each do |body_part| %>
+            <% next unless grouped_summary[body_part] %>
+            <% summary = grouped_summary[body_part] %>
+
+            <h2><%= body_part.humanize %></h2>
+
+            <p><strong>Entries:</strong> <%= summary[:count] %></p>
+            <p><strong>Start Date:</strong> <%= summary[:start_date]&.strftime("%B %d, %Y") %></p>
+            <p><strong>End Date:</strong> <%= summary[:end_date]&.strftime("%B %d, %Y") %></p>
+            <p><strong>Starting Value:</strong> <%= summary[:starting_value] %></p>
+            <p><strong>Ending Value:</strong> <%= summary[:ending_value] %></p>
+            <p><strong>Change:</strong> <%= summary[:change] %></p>
+            <p><strong>Minimum:</strong> <%= summary[:min] %></p>
+            <p><strong>Maximum:</strong> <%= summary[:max] %></p>
+            <p><strong>Average:</strong> <%= summary[:average] %></p>
+
+            <h3>History</h3>
+            <ul>
+                <% @report.measurements_grouped_by_body_part[body_part].each do |measurement| %>
+                <li>
+                    <%= link_to measurement.check_in.formatted_date, profile_check_in_path(@profile, measurement.check_in) %>: <%= measurement.value %>
+                </li>
+                <% end %>
+            </ul>
+
+            <hr>
+        <% end %>
+    <% else %>
+        <p>No measurements found for this timeframe.</p>
+    <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root "home#index"
 
   resources :profiles do
+    resource :report, only: [:show]
     resources :check_ins do
       resources :measurements
     end

--- a/spec/features/reports/report_spec.rb
+++ b/spec/features/reports/report_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "Report", type: :feature do
+  describe "progress reporting" do
+    let(:profile) do
+      Profile.create!(display_name: "Paul", default_unit: "in")
+    end
+
+    let!(:older_check_in) do
+      profile.check_ins.create!(
+        checked_in_on: Date.current - 60.days,
+        notes: "Older check-in"
+      )
+    end
+
+    let!(:recent_check_in) do
+      profile.check_ins.create!(
+        checked_in_on: Date.current - 7.days,
+        notes: "Recent check-in"
+      )
+    end
+
+    let!(:older_waist) do
+      older_check_in.measurements.create!(body_part: "waist", value: 36.0)
+    end
+
+    let!(:recent_waist) do
+      recent_check_in.measurements.create!(body_part: "waist", value: 34.0)
+    end
+
+    let!(:recent_chest) do
+      recent_check_in.measurements.create!(body_part: "chest", value: 42.0)
+    end
+
+    it "allows a user to view the progress report page" do
+      visit profile_path(profile)
+      click_link "View Progress Report"
+
+      expect(current_path).to eq(profile_report_path(profile))
+      expect(page).to have_content("Paul Progress Report")
+    end
+
+    it "shows summary and history together for each body part when no body part is selected" do
+        visit profile_report_path(profile)
+      
+        expect(page).to have_content("Waist")
+        expect(page).to have_content("Entries:")
+        expect(page).to have_content("History")
+        expect(page).to have_content("36.0")
+        expect(page).to have_content("34.0")
+      
+        expect(page).to have_content("Chest")
+        expect(page).to have_content("42.0")
+      end
+
+    it "filters the report by body part" do
+      visit profile_report_path(profile)
+
+      select "Waist", from: "Body Part"
+      click_button "Run Report"
+
+      expect(page).to have_content("Waist")
+      expect(page).to have_content("36.0")
+      expect(page).to have_content("34.0")
+      expect(page).not_to have_content("42.0")
+    end
+
+    it "filters the report by timeframe" do
+      visit profile_report_path(profile)
+
+      select "Waist", from: "Body Part"
+      select "30 days", from: "Timeframe"
+      click_button "Run Report"
+
+      expect(page).to have_content("34.0")
+      expect(page).not_to have_content("36.0")
+    end
+  end
+end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Reports", type: :request do
+  describe "GET /profiles/:profile_id/report" do
+    let(:profile) do
+      Profile.create!(display_name: "Paul", default_unit: "in")
+    end
+
+    it "returns http success" do
+      get profile_report_path(profile)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns http success with a selected body part and timeframe" do
+      get profile_report_path(profile), params: {
+        body_part: "waist",
+        timeframe: "30_days"
+      }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "redirects when the profile does not exist" do
+      get "/profiles/999999/report"
+
+      expect(response).to redirect_to(profiles_path)
+    end
+  end
+end

--- a/spec/services/measurement_report_spec.rb
+++ b/spec/services/measurement_report_spec.rb
@@ -58,12 +58,13 @@ RSpec.describe MeasurementReport do
 
   describe "#chart_data" do
     it "returns date and value pairs" do
-      report = described_class.new(profile: profile, body_part: "waist")
+      body_part = "waist"
+      report = described_class.new(profile: profile, body_part: body_part)
 
       expect(report.chart_data).to eq([
-        { date: older_check_in.checked_in_on, value: 36.0 },
-        { date: middle_check_in.checked_in_on, value: 35.0 },
-        { date: recent_check_in.checked_in_on, value: 34.0 }
+        { body_part: body_part, date: older_check_in.checked_in_on, value: 36.0 },
+        { body_part: body_part, date: middle_check_in.checked_in_on, value: 35.0 },
+        { body_part: body_part, date: recent_check_in.checked_in_on, value: 34.0 }
       ])
     end
   end
@@ -117,6 +118,22 @@ RSpec.describe MeasurementReport do
       report = described_class.new(profile: profile, body_part: "waist", timeframe: "all_time")
 
       expect(report.measurements).to eq([older_waist, middle_waist, recent_waist])
+    end
+  end
+  
+  describe "all body_parts summary" do
+    it "returns measurements for all body parts when no body_part is provided" do
+      report = described_class.new(profile: profile, body_part: nil)
+    
+      expect(report.measurements).to include(older_waist, middle_waist, recent_waist, recent_chest)
+    end
+    
+    it "returns grouped summary data when no body_part is provided" do
+      report = described_class.new(profile: profile, body_part: nil)
+    
+      expect(report.summary.keys).to include("waist", "chest")
+      expect(report.summary["waist"][:count]).to eq(3)
+      expect(report.summary["chest"][:count]).to eq(1)
     end
   end
 end

--- a/spec/services/measurement_report_spec.rb
+++ b/spec/services/measurement_report_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+RSpec.describe MeasurementReport do
+  let(:profile) do
+    Profile.create!(display_name: "Paul", default_unit: "in")
+  end
+
+  let!(:older_check_in) do
+    profile.check_ins.create!(
+      checked_in_on: Date.current - 60.days,
+      notes: "Older check-in"
+    )
+  end
+
+  let!(:middle_check_in) do
+    profile.check_ins.create!(
+      checked_in_on: Date.current - 30.days,
+      notes: "Middle check-in"
+    )
+  end
+
+  let!(:recent_check_in) do
+    profile.check_ins.create!(
+      checked_in_on: Date.current - 7.days,
+      notes: "Recent check-in"
+    )
+  end
+
+  let!(:older_waist) do
+    older_check_in.measurements.create!(body_part: "waist", value: 36.0)
+  end
+
+  let!(:middle_waist) do
+    middle_check_in.measurements.create!(body_part: "waist", value: 35.0)
+  end
+
+  let!(:recent_waist) do
+    recent_check_in.measurements.create!(body_part: "waist", value: 34.0)
+  end
+
+  let!(:recent_chest) do
+    recent_check_in.measurements.create!(body_part: "chest", value: 42.0)
+  end
+
+  describe "#measurements" do
+    it "returns measurements for the given body part in ascending date order" do
+      report = described_class.new(profile: profile, body_part: "waist")
+
+      expect(report.measurements).to eq([older_waist, middle_waist, recent_waist])
+    end
+
+    it "does not include other body parts" do
+      report = described_class.new(profile: profile, body_part: "waist")
+
+      expect(report.measurements).not_to include(recent_chest)
+    end
+  end
+
+  describe "#chart_data" do
+    it "returns date and value pairs" do
+      report = described_class.new(profile: profile, body_part: "waist")
+
+      expect(report.chart_data).to eq([
+        { date: older_check_in.checked_in_on, value: 36.0 },
+        { date: middle_check_in.checked_in_on, value: 35.0 },
+        { date: recent_check_in.checked_in_on, value: 34.0 }
+      ])
+    end
+  end
+
+  describe "#summary" do
+    it "returns summary statistics for the filtered measurements" do
+      report = described_class.new(profile: profile, body_part: "waist")
+
+      expect(report.summary).to include(
+        body_part: "waist",
+        timeframe: "all_time",
+        count: 3,
+        start_date: older_check_in.checked_in_on,
+        end_date: recent_check_in.checked_in_on,
+        starting_value: 36.0,
+        ending_value: 34.0,
+        change: -2.0,
+        min: 34.0,
+        max: 36.0,
+        average: 35.0
+      )
+    end
+
+    it "returns an empty summary when there are no matching measurements" do
+      report = described_class.new(profile: profile, body_part: "hips")
+
+      expect(report.summary).to include(
+        body_part: "hips",
+        timeframe: "all_time",
+        count: 0,
+        start_date: nil,
+        end_date: nil,
+        starting_value: nil,
+        ending_value: nil,
+        change: nil,
+        min: nil,
+        max: nil,
+        average: nil
+      )
+    end
+  end
+
+  describe "timeframe filtering" do
+    it "filters to the last 30 days" do
+      report = described_class.new(profile: profile, body_part: "waist", timeframe: "30_days")
+
+      expect(report.measurements).to eq([middle_waist, recent_waist])
+    end
+
+    it "returns all measurements for all_time" do
+      report = described_class.new(profile: profile, body_part: "waist", timeframe: "all_time")
+
+      expect(report.measurements).to eq([older_waist, middle_waist, recent_waist])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR introduces a new reporting feature that allows users to view measurement progress over time for a specific profile.

The reporting flow is built around a dedicated ReportsController and a MeasurementReport service object, keeping business logic separate from controllers and models.

The report supports:

* viewing all body parts together
* filtering by a specific body part
* filtering by timeframe
* viewing summary statistics
* viewing measurement history with links back to individual check-ins

This feature moves the application beyond CRUD into reporting and data analysis.

## Features Added
### Dedicated ReportsController

A new ReportsController was added to handle reporting separately from ProfilesController.

Routes are nested under profiles:

`/profiles/:profile_id/report`

This keeps profile CRUD concerns separate from reporting concerns.

### MeasurementReport Service Object

A new MeasurementReport service object was added to encapsulate reporting logic.

Responsibilities include:

* filtering measurements by profile
* optionally filtering by body part
* filtering by timeframe
* eager loading associated check-ins
* returning ordered measurement history
* generating summary statistics
* supporting grouped reporting when no body part is selected

This keeps the controller thin and makes the reporting logic reusable for future features like CSV export and charts.

### Body Part Filtering

The report supports filtering to a single body part, such as:

* weight
* chest
* waist
* hips
* shoulders
* bicep_left
* bicep_right
* thigh_left
* thigh_right

If no body part is selected, the report shows all available body parts.

### Timeframe Filtering

The report supports timeframe filtering using the following options:

* 30 days
* 90 days
* 6 months
* 1 year
* all time

This allows the user to narrow the report to a meaningful time window.

### Summary Statistics

For each report section, the application now calculates and displays:

* number of entries
* start date
* end date
* starting value
* ending value
* total change
* minimum value
* maximum value
* average value

When a single body part is selected, one summary is shown.

When no body part is selected, summaries are grouped by body part.

## Testing

### Service Specs
Added coverage for MeasurementReport, including:

* filtering by body part
* returning all body parts when none is selected
* timeframe filtering
* chart/history data structure
* summary statistics
* grouped summary output
* Request Specs

### Added request coverage for the report endpoint, including:

* successful report page load
* loading with body part and timeframe params
* redirect behavior when the profile does not exist

### Feature Specs

Added feature coverage for the reporting page, including:

* navigating from a profile to its progress report
* viewing all body parts
* filtering by body part
* filtering by timeframe