### PR TITLE
Add CSV Export for Profile Progress Reports

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,22 +1,40 @@
 class ReportsController < ApplicationController
-    before_action :set_profile
-  
-    def show
-      @body_part = params[:body_part].presence
-      @timeframe = params[:timeframe].presence || "all_time"
-  
-      @report = MeasurementReport.new(
-        profile: @profile,
-        body_part: @body_part,
-        timeframe: @timeframe
-      )
+  before_action :set_profile
+
+  def show
+    @body_part = params[:body_part].presence
+    @timeframe = params[:timeframe].presence || "all_time"
+
+    @report = MeasurementReport.new(
+      profile: @profile,
+      body_part: @body_part,
+      timeframe: @timeframe
+    )
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        exporter = MeasurementReportCsvExporter.new(report: @report)
+
+        send_data(
+          exporter.to_csv,
+          filename: csv_filename,
+          type: "text/csv"
+        )
+      end
     end
-  
-    private
-  
-    def set_profile
-      @profile = Profile.find(params[:profile_id])
-    rescue ActiveRecord::RecordNotFound
-      redirect_to profiles_path, alert: "Profile not found."
-    end
+  end
+
+  private
+
+  def set_profile
+    @profile = Profile.find(params[:profile_id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to profiles_path, alert: "Profile not found."
+  end
+
+  def csv_filename
+    body_part_segment = @body_part.presence || "all_body_parts"
+    "#{@profile.display_name.parameterize}-#{body_part_segment}-#{@timeframe}-report.csv"
+  end
 end

--- a/app/services/measurement_report_csv_exporter.rb
+++ b/app/services/measurement_report_csv_exporter.rb
@@ -1,0 +1,25 @@
+require "csv"
+
+class MeasurementReportCsvExporter
+  attr_reader :report
+
+  def initialize(report:)
+    @report = report
+  end
+
+  def to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << ["profile", "body_part", "check_in_date", "value", "timeframe"]
+
+      report.measurements.each do |measurement|
+        csv << [
+          report.profile.display_name,
+          measurement.body_part,
+          measurement.check_in.checked_in_on,
+          measurement.value,
+          report.timeframe
+        ]
+      end
+    end
+  end
+end

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,7 +1,14 @@
 <h1><%= @profile.display_name %> Progress Report</h1>
 
 <p>
-  <%= link_to "Back to Profile", profile_path(@profile) %>
+  <%= link_to "Back to Profile", profile_path(@profile) %> |
+  <%= link_to "Export CSV",
+      profile_report_path(
+        @profile,
+        format: :csv,
+        body_part: @body_part,
+        timeframe: @timeframe
+      ) %>
 </p>
 
 <%= form_with url: profile_report_path(@profile), method: :get, local: true do |form| %>

--- a/spec/features/reports/report_spec.rb
+++ b/spec/features/reports/report_spec.rb
@@ -75,5 +75,10 @@ RSpec.describe "Report", type: :feature do
       expect(page).to have_content("34.0")
       expect(page).not_to have_content("36.0")
     end
+
+    it "shows an export csv link" do
+      visit profile_report_path(profile)
+      expect(page).to have_link("Export CSV")
+    end
   end
 end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -6,24 +6,100 @@ RSpec.describe "Reports", type: :request do
       Profile.create!(display_name: "Paul", default_unit: "in")
     end
 
-    it "returns http success" do
-      get profile_report_path(profile)
+    let!(:older_check_in) do
+      profile.check_ins.create!(
+        checked_in_on: Date.current - 38.days,
+        notes: "Older check-in"
+      )
+    end
 
+    let!(:recent_check_in) do
+      profile.check_ins.create!(
+        checked_in_on: Date.current - 7.days,
+        notes: "Recent check-in"
+      )
+    end
+
+    let!(:older_waist) do
+      older_check_in.measurements.create!(
+        body_part: "waist",
+        value: 36.0
+      )
+    end
+
+    let!(:recent_waist) do
+      recent_check_in.measurements.create!(
+        body_part: "waist",
+        value: 34.5
+      )
+    end
+
+    let!(:recent_chest) do
+      recent_check_in.measurements.create!(
+        body_part: "chest",
+        value: 42.0
+      )
+    end
+
+    it "returns http success for html" do
+      get profile_report_path(profile)
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns http success with a selected body part and timeframe" do
-      get profile_report_path(profile), params: {
+    it "returns csv data for a selected body part" do
+      get profile_report_path(profile, format: :csv), params: {
+        body_part: "waist",
+        timeframe: "all_time"
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("text/csv")
+      expect(response.body).to include("profile,body_part,check_in_date,value,timeframe")
+      expect(response.body).to include("Paul,waist")
+      expect(response.body).to include(older_check_in.checked_in_on.to_s)
+      expect(response.body).to include(recent_check_in.checked_in_on.to_s)
+      expect(response.body).to include("36.0")
+      expect(response.body).to include("34.5")
+      expect(response.body).not_to include("chest")
+    end
+
+    it "returns csv data for all body parts when none is selected" do
+      get profile_report_path(profile, format: :csv), params: {
+        timeframe: "all_time"
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("text/csv")
+      expect(response.body).to include("profile,body_part,check_in_date,value,timeframe")
+      expect(response.body).to include("waist")
+      expect(response.body).to include("chest")
+      expect(response.body).to include("36.0")
+      expect(response.body).to include("34.5")
+      expect(response.body).to include("42.0")
+    end
+
+    it "filters csv data by timeframe" do
+      get profile_report_path(profile, format: :csv), params: {
         body_part: "waist",
         timeframe: "30_days"
       }
 
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include("34.5")
+      expect(response.body).not_to include("36.0")
+    end
+
+    it "sets a csv filename" do
+      get profile_report_path(profile, format: :csv), params: {
+        body_part: "waist",
+        timeframe: "30_days"
+      }
+
+      expect(response.headers["Content-Disposition"]).to include("paul-waist-30_days-report.csv")
     end
 
     it "redirects when the profile does not exist" do
       get "/profiles/999999/report"
-
       expect(response).to redirect_to(profiles_path)
     end
   end

--- a/spec/services/measurement_report_csv_exporter_spec.rb
+++ b/spec/services/measurement_report_csv_exporter_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe MeasurementReportCsvExporter do
+  let(:profile) do
+    Profile.create!(display_name: "Paul", default_unit: "in")
+  end
+
+  let!(:older_check_in) do
+    profile.check_ins.create!(
+      checked_in_on: Date.current - 30.days,
+      notes: "Older check-in"
+    )
+  end
+
+  let!(:recent_check_in) do
+    profile.check_ins.create!(
+      checked_in_on: Date.current - 7.days,
+      notes: "Recent check-in"
+    )
+  end
+
+  let!(:older_waist) do
+    older_check_in.measurements.create!(
+      body_part: "waist",
+      value: 36.0
+    )
+  end
+
+  let!(:recent_waist) do
+    recent_check_in.measurements.create!(
+      body_part: "waist",
+      value: 34.5
+    )
+  end
+
+  it "exports the report as csv" do
+    report = MeasurementReport.new(
+      profile: profile,
+      body_part: "waist",
+      timeframe: "all_time"
+    )
+
+    exporter = described_class.new(report: report)
+    csv_output = exporter.to_csv
+
+    expect(csv_output).to include("profile,body_part,check_in_date,value,timeframe")
+    expect(csv_output).to include("Paul,waist")
+    expect(csv_output).to include(older_check_in.checked_in_on.to_s)
+    expect(csv_output).to include(recent_check_in.checked_in_on.to_s)
+    expect(csv_output).to include("36.0")
+    expect(csv_output).to include("34.5")
+    expect(csv_output).to include("all_time")
+  end
+
+  it "exports all matching body parts when no body part is selected" do
+    recent_check_in.measurements.create!(
+      body_part: "chest",
+      value: 42.0
+    )
+
+    report = MeasurementReport.new(
+      profile: profile,
+      body_part: nil,
+      timeframe: "all_time"
+    )
+
+    exporter = described_class.new(report: report)
+    csv_output = exporter.to_csv
+
+    expect(csv_output).to include("waist")
+    expect(csv_output).to include("chest")
+  end
+end


### PR DESCRIPTION
## Summary

This PR introduces the ability to export progress report data as a CSV file.

The export functionality allows users to download measurement history for a profile using the same filters applied to the report page (body part and timeframe).

To maintain separation of concerns, CSV generation is implemented in a dedicated exporter service rather than being embedded directly in the reporting service.

## Features Added
### MeasurementReportCsvExporter Service

A new service object was added:

`MeasurementReportCsvExporter`

*Responsibilities:*

* Convert report measurement data into CSV format
* Serialize one row per measurement entry
* Include report context such as profile name and timeframe
* Remain independent of report calculation logic

This keeps the responsibilities clean:

MeasurementReport → report calculation and filtering
MeasurementReportCsvExporter → data export formatting
CSV Response in ReportsController


The ReportsController#show action now supports multiple response formats using respond_to.

Supported formats:
```
HTML – renders the standard progress report page
CSV – returns a downloadable CSV file
```
Example endpoint:

`/profiles/:profile_id/report.csv`

The CSV response uses send_data to stream the generated CSV file.

### Filter-Aware CSV Export

CSV exports respect the same filters used by the report page:

* Body part filter
* Timeframe filter

Example:

`/profiles/1/report.csv?body_part=waist&timeframe=30_days`

This ensures the downloaded CSV matches the report currently displayed to the user.

### Export CSV Link in Report View

An Export CSV link was added to the report page.

downloads the CSV report
preserves the currently selected filters
provides a simple export workflow for users
CSV Output Format

The CSV export produces one row per measurement entry with the following columns:

profile
body_part
check_in_date
value
timeframe

Example output:
```
profile,body_part,check_in_date,value,timeframe
Paul,waist,2026-03-01,36.0,all_time
Paul,waist,2026-04-01,34.5,all_time
```
This format keeps the export spreadsheet-friendly and easy to analyze in tools such as Excel or Google Sheets.

## Testing
### Service Specs

Added coverage for:

MeasurementReportCsvExporter

Tests verify:

CSV headers are generated correctly
report measurements are serialized correctly
filtering logic is respected through the report service
exports work for both single-body-part and multi-body-part reports
Request Specs

Added request-level tests for CSV export.

Tests verify:

CSV responses return HTTP success
response content type is text/csv
exported data includes expected measurements
timeframe filtering works correctly
body part filtering works correctly
CSV filename is set correctly
invalid profile requests redirect safely
Feature Specs

Added a feature test confirming that the Export CSV link appears on the report page.