### PR TITLE
Refactor profile measurement units from default_unit to unit_system

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -48,6 +48,6 @@ class ProfilesController < ApplicationController
   end
 
   def profile_params
-    params.require(:profile).permit(:display_name, :default_unit)
+    params.require(:profile).permit(:display_name, :unit_system)
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,25 +2,37 @@ class Profile < ApplicationRecord
   has_many :check_ins, dependent: :destroy
 
   scope :recent_first, -> { order(created_at: :desc) }
-  validates :display_name, presence: true, length: { minimum: 2, maximum: 50 }
-  validates :default_unit, presence: true, inclusion: { in: %w[in cm] }
 
-  def formatted_default_unit
-    case default_unit
-    when "in"
-      "Inches"
-    when "cm"
-      "Centimeters"
+  validates :display_name, presence: true, length: { minimum: 2, maximum: 50 }
+  validates :unit_system, presence: true, inclusion: { in: %w[imperial metric] }
+
+  def formatted_unit_system
+    case unit_system
+    when "imperial"
+      "Imperial"
+    when "metric"
+      "Metric"
     else
-      default_unit
+      unit_system
     end
   end
 
-  def abbreviated_default_unit
-    default_unit
+  def unit_for(body_part)
+    case unit_system
+    when "imperial"
+      body_part == "weight" ? "lb" : "in"
+    when "metric"
+      body_part == "weight" ? "kg" : "cm"
+    else
+      ""
+    end
   end
 
   def latest_check_in
     check_ins.reverse_chronological.first
   end
+
+  # def abbreviated_default_unit
+  #   default_unit
+  # end
 end

--- a/app/views/check_ins/show.html.erb
+++ b/app/views/check_ins/show.html.erb
@@ -55,7 +55,7 @@
             <li>
               <%= link_to measurement.formatted_body_part,
                   profile_check_in_measurement_path(@profile, @check_in, measurement) %>
-              : <%= measurement.value %> <%= @profile.abbreviated_default_unit %>
+              : <%= measurement.value %> <%= @profile.unit_for(measurement.body_part) %>
             </li>
           <% end %>
         </ul>

--- a/app/views/measurements/index.html.erb
+++ b/app/views/measurements/index.html.erb
@@ -24,7 +24,7 @@
         <div class="measurement-card-body">
           <p>
             <strong>Value:</strong>
-            <%= measurement.value %> <%= @profile.abbreviated_default_unit %>
+            <%= measurement.value %> <%= @profile.unit_for(measurement.body_part) %>
           </p>
 
           <p>

--- a/app/views/measurements/show.html.erb
+++ b/app/views/measurements/show.html.erb
@@ -30,7 +30,7 @@
 
       <p>
         <strong>Value:</strong>
-        <%= @measurement.value %> <%= @measurement.body_part %>
+        <%= @measurement.value %> <%= @profile.unit_for(@measurement.body_part) %>
       </p>
     </div>
 

--- a/app/views/measurements/show.html.erb
+++ b/app/views/measurements/show.html.erb
@@ -30,7 +30,7 @@
 
       <p>
         <strong>Value:</strong>
-        <%= @measurement.value %> <%= @profile.abbreviated_default_unit %>
+        <%= @measurement.value %> <%= @measurement.body_part %>
       </p>
     </div>
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -17,8 +17,8 @@
   </div>
 
   <div class="form-field">
-    <%= form.label :default_unit %>
-    <%= form.select :default_unit, [["Inches", "in"], ["Centimeters", "cm"]] %>
+    <%= form.label :unit_system %>
+    <%= form.select :unit_system, [["Imperial", "imperial"], ["Metric", "metric"]] %>
   </div>
 
   <div class="form-actions">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <strong>Default unit:</strong>
-  <%= @profile.formatted_default_unit %>
+  <%= @profile.formatted_unit_system %>
 </p>
 <div class="page-actions">
   <div class="page-actions-left">

--- a/db/migrate/20260412204239_rename_default_unit_to_unit_system_in_profiles.rb
+++ b/db/migrate/20260412204239_rename_default_unit_to_unit_system_in_profiles.rb
@@ -1,0 +1,6 @@
+class RenameDefaultUnitToUnitSystemInProfiles < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :profiles, :default_unit, :unit_system
+    change_column_default :profiles, :unit_system, "imperial"
+  end
+end

--- a/db/migrate/20260412212604_normalize_existing_profile_unit_systems.rb
+++ b/db/migrate/20260412212604_normalize_existing_profile_unit_systems.rb
@@ -1,0 +1,8 @@
+class NormalizeExistingProfileUnitSystems < ActiveRecord::Migration[7.1]
+  def up
+    execute <<~SQL
+      UPDATE profiles SET unit_system = 'imperial' WHERE unit_system = 'in';
+      UPDATE profiles SET unit_system = 'metric' WHERE unit_system = 'cm';
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_07_211041) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_12_212604) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,7 +64,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_07_211041) do
 
   create_table "profiles", force: :cascade do |t|
     t.string "display_name"
-    t.string "default_unit", default: "in"
+    t.string "unit_system", default: "in"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,7 @@ def sample_notes_for(profile_name)
       "Seeing some improvement in upper body measurements.",
       "Lower body work has been more consistent this month."
     ]
-  when "Taylor"
+  when "Shaina"
     [
       "Progress is steady and motivation has been high.",
       "Nutrition has been more structured this check-in period.",
@@ -51,7 +51,7 @@ end
 
 def measurement_templates_for(unit, profile_name)
   case [profile_name, unit]
-  when ["Paul", "in"]
+  when ["Paul", "imperial"]
     {
       "weight" => 188.0,
       "chest" => 42.5,
@@ -63,7 +63,7 @@ def measurement_templates_for(unit, profile_name)
       "thigh_left" => 23.4,
       "thigh_right" => 23.6
     }
-  when ["Jamie", "in"]
+  when ["Jamie", "imperial"]
     {
       "weight" => 172.0,
       "chest" => 39.5,
@@ -75,7 +75,7 @@ def measurement_templates_for(unit, profile_name)
       "thigh_left" => 22.0,
       "thigh_right" => 22.2
     }
-  when ["Taylor", "cm"]
+  when ["Shaina", "metric"]
     {
       "weight" => 81.0,
       "chest" => 104.0,
@@ -88,7 +88,7 @@ def measurement_templates_for(unit, profile_name)
       "thigh_right" => 57.5
     }
   else
-    if unit == "cm"
+    if unit == "metric"
       {
         "weight" => 84.0,
         "chest" => 107.0,
@@ -135,7 +135,7 @@ def adjusted_value(body_part, base_value, index, profile_name)
     case profile_name
     when "Paul" then 0.0
     when "Jamie" then 0.1
-    when "Taylor" then 0.2
+    when "Shaina" then 0.2
     else 0.0
     end
 
@@ -208,14 +208,14 @@ def attach_photo_set(check_in, photo_set)
   end
 end
 
-def create_profile_with_history(display_name:, default_unit:, day_offsets:, photo_sets:)
+def create_profile_with_history(display_name:, unit_system:, day_offsets:, photo_sets:)
   profile = Profile.create!(
     display_name: display_name,
-    default_unit: default_unit
+    unit_system: unit_system
   )
 
   notes = sample_notes_for(display_name)
-  templates = measurement_templates_for(default_unit, display_name)
+  templates = measurement_templates_for(unit_system, display_name)
 
   day_offsets.each_with_index do |day_offset, index|
     check_in = profile.check_ins.create!(
@@ -243,21 +243,21 @@ photo_sets = available_photo_sets.values
 
 create_profile_with_history(
   display_name: "Paul",
-  default_unit: "in",
+  unit_system: "imperial",
   day_offsets: [84, 63, 49, 35, 14, 3],
   photo_sets: photo_sets
 )
 
 create_profile_with_history(
   display_name: "Jamie",
-  default_unit: "in",
+  unit_system: "imperial",
   day_offsets: [90, 70, 52, 28, 12, 1],
   photo_sets: photo_sets.rotate(1)
 )
 
 create_profile_with_history(
-  display_name: "Taylor",
-  default_unit: "cm",
+  display_name: "Shaina",
+  unit_system: "metric",
   day_offsets: [95, 74, 58, 41, 19, 6],
   photo_sets: photo_sets.rotate(2)
 )

--- a/spec/features/check_in/check_in_crud_spec.rb
+++ b/spec/features/check_in/check_in_crud_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "CheckIn", type: :feature do
     describe "CRUD Functionality" do
-        let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+        let!(:profile) { Profile.create!(display_name: "Paul", unit_system: "imperial") }
 
         it "can create a new check-in" do
             visit new_profile_check_in_path(profile)
@@ -82,7 +82,7 @@ RSpec.describe "CheckIn", type: :feature do
         end
 
         it "shows a check-in's measurements on the check-in show page" do
-            profile = Profile.create!(display_name: "Paul", default_unit: "in")
+            profile = Profile.create!(display_name: "Paul", unit_system: "imperial")
             check_in = profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update")
             check_in.measurements.create!(body_part: "waist", value: 34.5)
             check_in.measurements.create!(body_part: "chest", value: 42.0)
@@ -97,7 +97,7 @@ RSpec.describe "CheckIn", type: :feature do
         end
 
         it "shows an empty state when a check-in has no measurements" do
-            profile = Profile.create!(display_name: "Paul", default_unit: "in")
+            profile = Profile.create!(display_name: "Paul", unit_system: "imperial")
             check_in = profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update")
             
             visit profile_check_in_path(profile, check_in)
@@ -107,7 +107,7 @@ RSpec.describe "CheckIn", type: :feature do
     end
 
     describe "sad paths / edge cases" do
-        let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+        let!(:profile) { Profile.create!(display_name: "Paul", unit_system: "imperial") }
 
         it "cannot create a check-in without a date" do
             visit new_profile_check_in_path(profile)

--- a/spec/features/check_in/check_in_photo_upload_spec.rb
+++ b/spec/features/check_in/check_in_photo_upload_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "CheckIn photo upload", type: :feature do
     it "can create a new check-in with progress photos" do
-        profile = Profile.create!(display_name: "Paul", default_unit: "in")
+        profile = Profile.create!(display_name: "Paul", unit_system: "imperial") 
     
         visit new_profile_check_in_path(profile)
     
@@ -24,7 +24,7 @@ RSpec.describe "CheckIn photo upload", type: :feature do
     end
 
     it "can update a check-in with progress photos" do
-        profile = Profile.create!(display_name: "Paul", default_unit: "in")
+        profile = Profile.create!(display_name: "Paul", unit_system: "imperial")
         check_in = profile.check_ins.create!(checked_in_on: Date.current, notes: "Original")
       
         visit edit_profile_check_in_path(profile, check_in)

--- a/spec/features/measurements/measurement_crud_spec.rb
+++ b/spec/features/measurements/measurement_crud_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Measurement", type: :feature do
   describe "CRUD Functionality" do
-    let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+    let!(:profile) { Profile.create!(display_name: "Paul", unit_system: "imperial") }
     let!(:check_in) { profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update") }
 
     it "can read multiple measurements" do
@@ -81,7 +81,7 @@ RSpec.describe "Measurement", type: :feature do
   end
 
   describe "sad paths / edge cases" do
-    let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+    let!(:profile) { Profile.create!(display_name: "Paul", unit_system: "imperial") }
     let!(:check_in) { profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update") }
 
     it "cannot create a measurement without a body part" do

--- a/spec/features/measurements/measurement_photo_upload_spec.rb
+++ b/spec/features/measurements/measurement_photo_upload_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Measurement photo upload", type: :feature do
     it "can create a new measurement with a body part photo" do
-        profile = Profile.create!(display_name: "Paul", default_unit: "in")
+        profile = Profile.create!(display_name: "Paul", unit_system: "imperial")
         check_in = profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update")
     
         visit new_profile_check_in_measurement_path(profile, check_in)
@@ -22,7 +22,7 @@ RSpec.describe "Measurement photo upload", type: :feature do
     end
 
     it "can update a measurement with a body part photo" do
-        profile = Profile.create!(display_name: "Paul", default_unit: "in")
+        profile = Profile.create!(display_name: "Paul", unit_system: "imperial")
         check_in = profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update")
         measurement = check_in.measurements.create!(body_part: "waist", value: 34.5)
       

--- a/spec/features/profile/profile_crud_spec.rb
+++ b/spec/features/profile/profile_crud_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Profile", type: :feature do
             expect(current_path).to eq("/profiles/new")
 
             fill_in "Display name", with: "John-Patrick"
-            select "Inches", from: "Default unit"
+            select "Imperial", from: "Unit system"
 
             click_button "Create Profile"
 
@@ -17,16 +17,16 @@ RSpec.describe "Profile", type: :feature do
         end
 
         it "can read a single profile/profile show" do
-            Profile.create!(display_name: "Pauly Do Little", default_unit: "in")
+            Profile.create!(display_name: "Pauly Do Little", unit_system: "imperial")
             visit "/profiles/#{Profile.last.id}"
             expect(page).to have_content("Pauly Do Little")
         end
 
         it "can read multiple profiles/profile index" do
-            Profile.create!(display_name: "Pauly Do Lottle", default_unit: "in")
-            Profile.create!(display_name: "Hope Johnstein", default_unit: "in")
-            Profile.create!(display_name: "John Hopenstein", default_unit: "in")
-            Profile.create!(display_name: "Harry Buttler", default_unit: "in")
+            Profile.create!(display_name: "Pauly Do Lottle", unit_system: "imperial")
+            Profile.create!(display_name: "Hope Johnstein", unit_system: "imperial")
+            Profile.create!(display_name: "John Hopenstein", unit_system: "imperial")
+            Profile.create!(display_name: "Harry Buttler", unit_system: "imperial")
 
             visit "/profiles"
             expect(page).to have_content("Pauly Do Lottle")
@@ -36,7 +36,7 @@ RSpec.describe "Profile", type: :feature do
         end
 
         it "can update a profile" do
-            profile_1 = Profile.create!(display_name: "Pauly Do Lottle", default_unit: "in")
+            profile_1 = Profile.create!(display_name: "Pauly Do Lottle", unit_system: "imperial")
 
             visit "profiles/#{profile_1.id}"
             expect(current_path).to eq("/profiles/#{profile_1.id}")
@@ -52,8 +52,8 @@ RSpec.describe "Profile", type: :feature do
         end
 
         it "can destroy a profile" do
-            profile_1 = Profile.create!(display_name: "Pauly Do Lottle", default_unit: "in")
-            profile_2 = Profile.create!(display_name: "Harry Buttler", default_unit: "in")
+            profile_1 = Profile.create!(display_name: "Pauly Do Lottle", unit_system: "imperial")
+            profile_2 = Profile.create!(display_name: "Harry Buttler", unit_system: "imperial")
 
             expect(Profile.all.count).to eq(2)
             visit "profiles" 
@@ -74,7 +74,7 @@ RSpec.describe "Profile", type: :feature do
             expect(current_path).to eq("/profiles/new")
 
             fill_in "Display name", with: ""
-            select "Inches", from: "Default unit"
+            select "Imperial", from: "Unit system"
 
             click_button "Create Profile"
             expect(page).to have_content("Display name can't be blank")
@@ -91,7 +91,7 @@ RSpec.describe "Profile", type: :feature do
             visit "/profiles/new"
           
             fill_in "Display name", with: "J"
-            select "Inches", from: "Default unit"
+            select "Imperial", from: "Unit system"
             click_button "Create Profile"
           
             expect(page).to have_content("Display name is too short")
@@ -101,19 +101,19 @@ RSpec.describe "Profile", type: :feature do
             visit "/profiles/new"
           
             fill_in "Display name", with: "J" * 51
-            select "Inches", from: "Default unit"
+            select "Imperial", from: "Unit system"
             click_button "Create Profile"
           
             expect(page).to have_content("Display name is too long")
         end
 
         it "cannot update a profile with invalid data" do
-            profile = Profile.create!(display_name: "John", default_unit: "in")
+            profile = Profile.create!(display_name: "John", unit_system: "imperial")
           
             visit edit_profile_path(profile)
           
             fill_in "Display name", with: ""
-            select "Inches", from: "Default unit"
+            select "Imperial", from: "Unit system"
             click_button "Update Profile"
           
             expect(page).to have_content("Display name can't be blank")
@@ -138,7 +138,7 @@ RSpec.describe "Profile", type: :feature do
 
     describe "profile functionality" do
         it "links a profile's check-ins to their show pages" do
-            profile = Profile.create!(display_name: "John-Patrick", default_unit: "in")
+            profile = Profile.create!(display_name: "John-Patrick", unit_system: "imperial")
             check_in = profile.check_ins.create!(
               checked_in_on: Date.current,
               notes: "Weekly progress update"

--- a/spec/features/reports/report_spec.rb
+++ b/spec/features/reports/report_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Report", type: :feature do
   describe "progress reporting" do
     let(:profile) do
-      Profile.create!(display_name: "Paul", default_unit: "in")
+      Profile.create!(display_name: "Paul", unit_system: "imperial")
     end
 
     let!(:older_check_in) do

--- a/spec/models/check_in_spec.rb
+++ b/spec/models/check_in_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CheckIn, type: :model do
     )
   end
 
-  let(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+  let(:profile) { Profile.create!(display_name: "Paul", unit_system: "imperial") }
 
   describe "associations" do
     it { should belong_to(:profile) }
@@ -97,7 +97,7 @@ RSpec.describe CheckIn, type: :model do
     end
 
     it "allows the same check-in date for different profiles" do
-      other_profile = Profile.create!(display_name: "Jamie", default_unit: "in")
+      other_profile = Profile.create!(display_name: "Jamie", unit_system: "imperial")
     
       described_class.create!(
         profile: profile,

--- a/spec/models/measurement_spec.rb
+++ b/spec/models/measurement_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Measurement, type: :model do
   let(:profile) do
-    Profile.create!(display_name: "JP", default_unit: "in")
+    Profile.create!(display_name: "JP", unit_system: "imperial")
   end
 
   let(:check_in) do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Profile, type: :model do
-    subject(:profile) {described_class.new(display_name: "Paul", default_unit: "in")}
+    subject(:profile) {described_class.new(display_name: "Paul", unit_system: "imperial")}
     describe "profile must be valid" do
         it "has valid attributes" do
             expect(profile).to be_valid
@@ -13,21 +13,21 @@ RSpec.describe Profile, type: :model do
         end
 
         it "has a default unit" do
-            profile.default_unit = nil
+            profile.unit_system = nil
             expect(profile).not_to be_valid
         end
 
-        it "is invalid with an unsupported default_unit" do
-            profile.default_unit = "lbs"
+        it "is invalid with an unsupported unit_system" do
+            profile.unit_system = "lbs"
             expect(profile).not_to be_valid
         end
     end
     
-    describe "#abbreviated_default_unit" do
-        it "returns the default unit abbreviation" do
-          profile = described_class.new(display_name: "Paul", default_unit: "in")
+    # describe "#abbreviated_unit_system" do
+    #     it "returns the default unit abbreviation" do
+    #       profile = described_class.new(display_name: "Paul", unit_system: "imperial")
       
-          expect(profile.abbreviated_default_unit).to eq("in")
-        end
-    end
+    #       expect(profile.abbreviated_unit_system).to eq("imperial")
+    #     end
+    # end
 end

--- a/spec/requests/check_ins_spec.rb
+++ b/spec/requests/check_ins_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "CheckIns", type: :request do
-  let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+  let!(:profile) { Profile.create!(display_name: "Paul", unit_system: "imperial") }
 
   describe "GET /profiles/:profile_id/check_ins" do
     it "returns http success" do
@@ -159,7 +159,7 @@ RSpec.describe "CheckIns", type: :request do
   
   describe "checkin photo upload" do
     it "creates a check-in with an upper front photo" do
-      profile = Profile.create!(display_name: "Paul", default_unit: "in")
+      profile = Profile.create!(display_name: "Paul", unit_system: "imperial")
       image = test_image_upload("upper_front.png")
     
       post profile_check_ins_path(profile), params: {

--- a/spec/requests/measurements_spec.rb
+++ b/spec/requests/measurements_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Measurements", type: :request do
-  let!(:profile) { Profile.create!(display_name: "Paul", default_unit: "in") }
+  let!(:profile) { Profile.create!(display_name: "Paul", unit_system: "imperial") }
   let!(:check_in) { profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update") }
 
   describe "GET /profiles/:profile_id/check_ins/:check_in_id/measurements" do
@@ -153,7 +153,7 @@ RSpec.describe "Measurements", type: :request do
 
   describe "measurement" do
     it "creates a measurement with a body part photo" do
-      profile = Profile.create!(display_name: "Paul", default_unit: "in")
+      profile = Profile.create!(display_name: "Paul", unit_system: "imperial")
       check_in = profile.check_ins.create!(checked_in_on: Date.current, notes: "Weekly update")
       image = test_image_upload("upper_front.png")
 

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Profiles", type: :request do
           post profiles_path, params: {
             profile: {
               display_name: "Paul",
-              default_unit: "in"
+              unit_system: "imperial"
             }
           }
         }.to change(Profile, :count).by(1)
@@ -31,7 +31,7 @@ RSpec.describe "Profiles", type: :request do
           post profiles_path, params: {
             profile: {
               display_name: "",
-              default_unit: ""
+              unit_system: ""
             }
           }
         }.not_to change(Profile, :count)

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Reports", type: :request do
   describe "GET /profiles/:profile_id/report" do
     let(:profile) do
-      Profile.create!(display_name: "Paul", default_unit: "in")
+      Profile.create!(display_name: "Paul", unit_system: "imperial")
     end
 
     let!(:older_check_in) do

--- a/spec/services/measurement_report_csv_exporter_spec.rb
+++ b/spec/services/measurement_report_csv_exporter_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe MeasurementReportCsvExporter do
   let(:profile) do
-    Profile.create!(display_name: "Paul", default_unit: "in")
+    Profile.create!(display_name: "Paul", unit_system: "imperial")
   end
 
   let!(:older_check_in) do

--- a/spec/services/measurement_report_spec.rb
+++ b/spec/services/measurement_report_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe MeasurementReport do
   let(:profile) do
-    Profile.create!(display_name: "Paul", default_unit: "in")
+    Profile.create!(display_name: "Paul", unit_system: "imperial")
   end
 
   let!(:older_check_in) do


### PR DESCRIPTION
Refactors the profiles table to rename default_unit to unit_system, updating the database column, default value, and associated references. This change prepares the application for supporting measurement systems (Imperial/Metric) instead of individual units.