### PR TITLE
Add interactive progress photo comparison slider with Turbo Frame filtering

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -292,12 +292,6 @@ button:hover {
     margin-top: 1rem;
   }
   
-  @media (max-width: 768px) {
-    .photo-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-  
   .photo-card {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -909,24 +903,47 @@ a.button-link.subtle-link:hover {
   background: #f3f4f6;
 }
 
+.photo-timeline-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.photo-timeline-meta p {
+  margin: 0.35rem 0;
+}
+
+.photo-timeline-viewer .photo-card {
+  max-width: 420px;
+}
+
   /* mobile compatibility */
-  @media (max-width: 768px) {
-    .navbar-inner {
-      flex-direction: column;
-      align-items: stretch;
-      gap: 0.75rem;
-    }
+@media (max-width: 768px) {
+  .navbar-inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .photo-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .photo-timeline-shell {
+    grid-template-columns: 1fr;
+  }
   
-    .navbar-left,
-    .navbar-right {
-      flex-wrap: wrap;
-      gap: 0.5rem;
-    }
-  
-    .page-shell {
-      margin: 1rem auto;
-      padding: 0 1rem 1.5rem;
-    }
+  .navbar-left,
+  .navbar-right {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .page-shell {
+    margin: 1rem auto;
+    padding: 0 1rem 1.5rem;
+  }
   
     .page-card,
     .detail-card,

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -916,6 +916,7 @@ a.button-link.subtle-link:hover {
 
 .photo-timeline-viewer .photo-card {
   max-width: 420px;
+  width: 100%;
 }
 
 .photo-timeline-slider-wrap {
@@ -935,6 +936,92 @@ a.button-link.subtle-link:hover {
   width: 100%;
   cursor: pointer;
 }
+
+/* Profile photos slider */
+.photo-timeline-viewer .progress-photo {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  object-fit: cover;
+  border-radius: 12px;
+  display: block;
+}
+
+.photo-comparison {
+  max-width: 520px;
+  margin-top: 1rem;
+}
+
+.photo-comparison-meta p {
+  margin: 0.35rem 0;
+}
+
+.photo-comparison-image-wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  overflow: hidden;
+  border-radius: 14px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.photo-comparison-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.photo-comparison-overlay {
+  position: absolute;
+  inset: 0;
+  width: 50%;
+  overflow: hidden;
+}
+
+.photo-comparison-overlay .overlay-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.photo-comparison-divider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 3px;
+  background: #ffffff;
+  box-shadow: 0 0 0 1px rgba(17, 24, 39, 0.2);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.photo-comparison-label {
+  position: absolute;
+  top: 0.75rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.8);
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.oldest-label {
+  left: 0.75rem;
+}
+
+.newest-label {
+  right: 0.75rem;
+}
+
+.photo-comparison-slider {
+  width: 100%;
+  margin-top: 1rem;
+  cursor: pointer;
+}
+
 
   /* mobile compatibility */
 @media (max-width: 768px) {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -918,6 +918,24 @@ a.button-link.subtle-link:hover {
   max-width: 420px;
 }
 
+.photo-timeline-slider-wrap {
+  margin-top: 1rem;
+}
+
+.photo-timeline-slider-labels {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: #4b5563;
+  margin-bottom: 0.5rem;
+}
+
+.photo-timeline-slider {
+  width: 100%;
+  cursor: pointer;
+}
+
   /* mobile compatibility */
 @media (max-width: 768px) {
   .navbar-inner {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -938,63 +938,74 @@ a.button-link.subtle-link:hover {
 }
 
 /* Profile photos slider */
-.photo-timeline-viewer .progress-photo {
-  width: 100%;
-  aspect-ratio: 3 / 4;
-  object-fit: cover;
-  border-radius: 12px;
-  display: block;
-}
-
-.photo-comparison {
-  max-width: 520px;
-  margin-top: 1rem;
-}
-
-.photo-comparison-meta p {
-  margin: 0.35rem 0;
-}
-
 .photo-comparison-image-wrap {
   position: relative;
   width: 100%;
   aspect-ratio: 3 / 4;
   overflow: hidden;
-  border-radius: 14px;
-  border: 1px solid #e5e7eb;
-  background: #f9fafb;
+  --comparison-position: 50%;
+}
+
+.photo-comparison {
+  max-width: 520px;
+  margin: 1rem auto 0;
+  width: 100%;
 }
 
 .photo-comparison-image {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
+  max-width: none;
   object-fit: cover;
   display: block;
+}
+
+.base-image {
+  z-index: 1;
 }
 
 .photo-comparison-overlay {
   position: absolute;
   inset: 0;
-  width: 50%;
-  overflow: hidden;
+  z-index: 2;
+  clip-path: inset(0 calc(100% - var(--comparison-position)) 0 0);
 }
 
-.photo-comparison-overlay .overlay-image {
+.overlay-image {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
+  max-width: none;
   object-fit: cover;
+  display: block;
 }
 
 .photo-comparison-divider {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 50%;
+  left: var(--comparison-position);
   width: 3px;
   background: #ffffff;
   box-shadow: 0 0 0 1px rgba(17, 24, 39, 0.2);
   transform: translateX(-50%);
   pointer-events: none;
+  z-index: 3;
+}
+
+.photo-comparison-handle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 0 0 1px rgba(17, 24, 39, 0.2);
+  transform: translate(-50%, -50%);
 }
 
 .photo-comparison-label {
@@ -1006,6 +1017,7 @@ a.button-link.subtle-link:hover {
   color: #ffffff;
   font-size: 0.8rem;
   font-weight: 600;
+  z-index: 4;
 }
 
 .oldest-label {
@@ -1017,9 +1029,53 @@ a.button-link.subtle-link:hover {
 }
 
 .photo-comparison-slider {
+  position: absolute;
+  inset: 0;
   width: 100%;
-  margin-top: 1rem;
-  cursor: pointer;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: ew-resize;
+  z-index: 5;
+}
+
+.photo-comparison-title {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.photo-comparison-title {
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.photo-comparison-toggle-row {
+  max-width: 520px;
+  margin: 0 auto 0.25rem;
+  display: flex;
+  justify-content: center;
+}
+
+.photo-comparison-toggle-row .chart-toggle-group {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.photo-comparison {
+  max-width: 520px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.photo-comparison-meta {
+  margin-top: 0.75rem;
+}
+
+.photo-comparison-meta p {
+  margin: 0.25rem 0;
+  text-align: left;
 }
 
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,6 +7,8 @@ class ProfilesController < ApplicationController
 
   def show
     @check_ins = @profile.check_ins.reverse_chronological
+    @photo_type = params[:photo_type].presence || "front_photo"
+    @photo_timeline = ProfilePhotoTimeline.new(profile: @profile, photo_type: @photo_type)
   end
 
   def new

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -14,15 +14,12 @@ function initializePhotoComparisons() {
     comparison.dataset.initialized = "true";
 
     const slider = comparison.querySelector("[data-photo-comparison-slider]");
-    const overlay = comparison.querySelector("[data-photo-comparison-overlay]");
-    const divider = comparison.querySelector("[data-photo-comparison-divider]");
+    const wrapper = comparison.querySelector(".photo-comparison-image-wrap");
 
-    if (!slider || !overlay || !divider) return;
+    if (!slider || !wrapper) return;
 
     const updateComparison = () => {
-      const value = `${slider.value}%`;
-      overlay.style.width = value;
-      divider.style.left = value;
+      wrapper.style.setProperty("--comparison-position", `${slider.value}%`);
     };
 
     slider.addEventListener("input", updateComparison);

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,29 +5,27 @@ import "chartkick"
 import "Chart.bundle"
 
 
-document.addEventListener("turbo:load", initializePhotoTimelines);
-document.addEventListener("turbo:frame-load", initializePhotoTimelines);
+document.addEventListener("turbo:load", initializePhotoComparisons);
+document.addEventListener("turbo:frame-load", initializePhotoComparisons);
 
-function initializePhotoTimelines() {
-  document.querySelectorAll("[data-photo-timeline]").forEach((timeline) => {
-    if (timeline.dataset.initialized === "true") return;
-    timeline.dataset.initialized = "true";
+function initializePhotoComparisons() {
+  document.querySelectorAll("[data-photo-comparison]").forEach((comparison) => {
+    if (comparison.dataset.initialized === "true") return;
+    comparison.dataset.initialized = "true";
 
-    const photos = JSON.parse(timeline.dataset.photos || "[]");
-    const slider = timeline.querySelector("[data-photo-timeline-slider]");
-    const image = timeline.querySelector("[data-photo-timeline-image]");
-    const dateLabel = timeline.querySelector("[data-photo-timeline-date]");
+    const slider = comparison.querySelector("[data-photo-comparison-slider]");
+    const overlay = comparison.querySelector("[data-photo-comparison-overlay]");
+    const divider = comparison.querySelector("[data-photo-comparison-divider]");
 
-    if (!slider || !image || !dateLabel || photos.length === 0) return;
+    if (!slider || !overlay || !divider) return;
 
-    const updateTimeline = () => {
-      const selectedPhoto = photos[Number(slider.value)];
-      if (!selectedPhoto) return;
-
-      image.src = selectedPhoto.url;
-      dateLabel.textContent = selectedPhoto.date;
+    const updateComparison = () => {
+      const value = `${slider.value}%`;
+      overlay.style.width = value;
+      divider.style.left = value;
     };
 
-    slider.addEventListener("input", updateTimeline);
+    slider.addEventListener("input", updateComparison);
+    updateComparison();
   });
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,31 @@ import "@hotwired/turbo-rails"
 import "controllers"
 import "chartkick"
 import "Chart.bundle"
+
+
+document.addEventListener("turbo:load", initializePhotoTimelines);
+document.addEventListener("turbo:frame-load", initializePhotoTimelines);
+
+function initializePhotoTimelines() {
+  document.querySelectorAll("[data-photo-timeline]").forEach((timeline) => {
+    if (timeline.dataset.initialized === "true") return;
+    timeline.dataset.initialized = "true";
+
+    const photos = JSON.parse(timeline.dataset.photos || "[]");
+    const slider = timeline.querySelector("[data-photo-timeline-slider]");
+    const image = timeline.querySelector("[data-photo-timeline-image]");
+    const dateLabel = timeline.querySelector("[data-photo-timeline-date]");
+
+    if (!slider || !image || !dateLabel || photos.length === 0) return;
+
+    const updateTimeline = () => {
+      const selectedPhoto = photos[Number(slider.value)];
+      if (!selectedPhoto) return;
+
+      image.src = selectedPhoto.url;
+      dateLabel.textContent = selectedPhoto.date;
+    };
+
+    slider.addEventListener("input", updateTimeline);
+  });
+}

--- a/app/services/profile_photo_timeline.rb
+++ b/app/services/profile_photo_timeline.rb
@@ -1,0 +1,50 @@
+class ProfilePhotoTimeline
+    PHOTO_TYPES = %w[front_photo side_photo back_photo].freeze
+  
+    attr_reader :profile, :photo_type
+  
+    def initialize(profile:, photo_type: "front_photo")
+      @profile = profile
+      @photo_type = normalize_photo_type(photo_type)
+    end
+  
+    def photos
+      @photos ||= begin
+        profile.check_ins
+          .chronological
+          .select { |check_in| check_in.public_send(photo_type).attached? }
+          .map do |check_in|
+            {
+              check_in_id: check_in.id,
+              checked_in_on: check_in.checked_in_on,
+              formatted_date: check_in.formatted_date,
+              attachment: check_in.public_send(photo_type)
+            }
+          end
+      end
+    end
+  
+    def any_photos?
+      photos.any?
+    end
+  
+    def oldest_photo
+      photos.first
+    end
+  
+    def newest_photo
+      photos.last
+    end
+  
+    def photo_type_label
+      photo_type.delete_suffix("_photo").humanize
+    end
+  
+    private
+  
+    def normalize_photo_type(value)
+      return value if PHOTO_TYPES.include?(value)
+  
+      "front_photo"
+    end
+  end

--- a/app/services/profile_photo_timeline.rb
+++ b/app/services/profile_photo_timeline.rb
@@ -39,6 +39,10 @@ class ProfilePhotoTimeline
     def photo_type_label
       photo_type.delete_suffix("_photo").humanize
     end
+
+    def comparable?
+        photos.size >= 2
+    end
   
     private
   

--- a/app/views/profiles/_photo_timeline.html.erb
+++ b/app/views/profiles/_photo_timeline.html.erb
@@ -1,75 +1,63 @@
-<%= turbo_frame_tag "profile_photo_timeline" do %>
-  <div class="detail-card">
-    <div class="chart-card-header">
-      <h2>Progress Photo Comparison</h2>
+<div class="detail-card">
+<h2 class="photo-comparison-title">Progress Photo Comparison</h2>
 
-      <div class="chart-toggle-group">
-        <% ProfilePhotoTimeline::PHOTO_TYPES.each do |type| %>
-          <%= link_to type.delete_suffix("_photo").humanize,
-              profile_path(@profile, photo_type: type),
-              class: "chart-toggle-button #{'active' if @photo_type == type}",
-              data: { turbo_frame: "profile_photo_timeline" } %>
-        <% end %>
-      </div>
-    </div>
-
-    <% if @photo_timeline.comparable? %>
-      <div class="photo-comparison-meta">
-        <p>
-          <strong>Comparing:</strong>
-          <%= @photo_timeline.photo_type_label %>
-        </p>
-        <p>
-          <strong>Oldest:</strong>
-          <%= @photo_timeline.oldest_photo[:formatted_date] %>
-        </p>
-        <p>
-          <strong>Most Recent:</strong>
-          <%= @photo_timeline.newest_photo[:formatted_date] %>
-        </p>
-      </div>
-
-      <div class="photo-comparison"
-           data-photo-comparison>
-        <div class="photo-comparison-image-wrap">
-          <%= image_tag @photo_timeline.oldest_photo[:attachment],
-              class: "photo-comparison-image base-image" %>
-
-          <div class="photo-comparison-overlay" data-photo-comparison-overlay>
-            <%= image_tag @photo_timeline.newest_photo[:attachment],
-                class: "photo-comparison-image overlay-image" %>
-          </div>
-
-          <div class="photo-comparison-divider" data-photo-comparison-divider></div>
-
-          <div class="photo-comparison-label oldest-label">
-            Oldest
-          </div>
-
-          <div class="photo-comparison-label newest-label">
-            Most Recent
-          </div>
-        </div>
-
-        <input type="range"
-               min="0"
-               max="100"
-               value="50"
-               class="photo-comparison-slider"
-               data-photo-comparison-slider>
-      </div>
-    <% elsif @photo_timeline.any_photos? %>
-      <p>
-        Only one <%= @photo_timeline.photo_type_label.downcase %> photo is available so far.
-        Upload at least one older and one newer photo to compare progress.
-      </p>
-
-      <div class="photo-card">
-        <p><strong><%= @photo_timeline.photo_type_label %></strong></p>
-        <%= image_tag @photo_timeline.newest_photo[:attachment], class: "progress-photo" %>
-      </div>
-    <% else %>
-      <p>No <%= @photo_timeline.photo_type_label.downcase %> photos yet.</p>
+<div class="photo-comparison-toggle-row">
+  <div class="chart-toggle-group">
+    <% ProfilePhotoTimeline::PHOTO_TYPES.each do |type| %>
+      <%= link_to type.delete_suffix("_photo").humanize,
+          profile_path(@profile, photo_type: type),
+          class: "chart-toggle-button #{'active' if @photo_type == type}",
+          data: { turbo_frame: "profile_photo_timeline" } %>
     <% end %>
   </div>
+</div>
+
+<% if @photo_timeline.comparable? %>
+  <div class="photo-comparison"
+       data-photo-comparison>
+    <div class="photo-comparison-image-wrap">
+      <%= image_tag @photo_timeline.oldest_photo[:attachment],
+          class: "photo-comparison-image base-image" %>
+
+      <div class="photo-comparison-overlay" data-photo-comparison-overlay>
+        <%= image_tag @photo_timeline.newest_photo[:attachment],
+            class: "photo-comparison-image overlay-image" %>
+      </div>
+
+      <div class="photo-comparison-divider" data-photo-comparison-divider>
+        <div class="photo-comparison-handle"></div>
+      </div>
+
+      <div class="photo-comparison-label oldest-label">Oldest</div>
+      <div class="photo-comparison-label newest-label">Most Recent</div>
+
+      <input type="range"
+             min="0"
+             max="100"
+             value="50"
+             class="photo-comparison-slider"
+             data-photo-comparison-slider>
+    </div>
+
+    <div class="photo-comparison-meta">
+      <p><strong>Comparing:</strong> <%= @photo_timeline.photo_type_label %></p>
+      <p><strong>Oldest:</strong> <%= @photo_timeline.oldest_photo[:formatted_date] %></p>
+      <p><strong>Most Recent:</strong> <%= @photo_timeline.newest_photo[:formatted_date] %></p>
+    </div>
+  </div>
+<% elsif @photo_timeline.any_photos? %>
+  <div class="photo-comparison">
+    <div class="photo-card">
+      <p><strong><%= @photo_timeline.photo_type_label %></strong></p>
+      <%= image_tag @photo_timeline.newest_photo[:attachment], class: "progress-photo" %>
+    </div>
+
+    <div class="photo-comparison-meta">
+      <p>Only one <%= @photo_timeline.photo_type_label.downcase %> photo is available so far.</p>
+      <p>Upload at least one older and one newer photo to compare progress.</p>
+    </div>
+  </div>
+<% else %>
+  <p>No <%= @photo_timeline.photo_type_label.downcase %> photos yet.</p>
 <% end %>
+  </div>

--- a/app/views/profiles/_photo_timeline.html.erb
+++ b/app/views/profiles/_photo_timeline.html.erb
@@ -30,11 +30,46 @@
           </p>
         </div>
 
-        <div class="photo-timeline-viewer">
+        <div class="photo-timeline-viewer"
+             data-photo-timeline
+             data-photos="<%= raw(
+               @photo_timeline.photos.map { |photo|
+                 {
+                   url: url_for(photo[:attachment]),
+                   date: photo[:formatted_date]
+                 }
+               }.to_json
+             ) %>">
+
           <div class="photo-card">
-            <p><strong><%= @photo_timeline.photo_type_label %></strong></p>
-            <%= image_tag @photo_timeline.newest_photo[:attachment], class: "progress-photo", id: "timeline-photo-preview" %>
+            <p>
+              <strong><%= @photo_timeline.photo_type_label %></strong>
+              -
+              <span data-photo-timeline-date><%= @photo_timeline.oldest_photo[:formatted_date] %></span>
+            </p>
+
+            <%= image_tag @photo_timeline.oldest_photo[:attachment],
+                class: "progress-photo",
+                id: "timeline-photo-preview",
+                data: { photo_timeline_image: true } %>
           </div>
+
+          <% if @photo_timeline.photos.size > 1 %>
+            <div class="photo-timeline-slider-wrap">
+              <div class="photo-timeline-slider-labels">
+                <span><%= @photo_timeline.oldest_photo[:formatted_date] %></span>
+                <span><%= @photo_timeline.newest_photo[:formatted_date] %></span>
+              </div>
+
+              <input type="range"
+                     min="0"
+                     max="<%= @photo_timeline.photos.size - 1 %>"
+                     value="0"
+                     step="1"
+                     class="photo-timeline-slider"
+                     data-photo-timeline-slider>
+            </div>
+          <% end %>
         </div>
       </div>
     <% else %>

--- a/app/views/profiles/_photo_timeline.html.erb
+++ b/app/views/profiles/_photo_timeline.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "profile_photo_timeline" do %>
   <div class="detail-card">
     <div class="chart-card-header">
-      <h2>Progress Photo Timeline</h2>
+      <h2>Progress Photo Comparison</h2>
 
       <div class="chart-toggle-group">
         <% ProfilePhotoTimeline::PHOTO_TYPES.each do |type| %>
@@ -13,64 +13,60 @@
       </div>
     </div>
 
-    <% if @photo_timeline.any_photos? %>
-      <div class="photo-timeline-shell">
-        <div class="photo-timeline-meta">
-          <p>
-            <strong>Showing:</strong>
-            <%= @photo_timeline.photo_type_label %>
-          </p>
-          <p>
-            <strong>Oldest:</strong>
-            <%= @photo_timeline.oldest_photo[:formatted_date] %>
-          </p>
-          <p>
-            <strong>Most Recent:</strong>
-            <%= @photo_timeline.newest_photo[:formatted_date] %>
-          </p>
-        </div>
+    <% if @photo_timeline.comparable? %>
+      <div class="photo-comparison-meta">
+        <p>
+          <strong>Comparing:</strong>
+          <%= @photo_timeline.photo_type_label %>
+        </p>
+        <p>
+          <strong>Oldest:</strong>
+          <%= @photo_timeline.oldest_photo[:formatted_date] %>
+        </p>
+        <p>
+          <strong>Most Recent:</strong>
+          <%= @photo_timeline.newest_photo[:formatted_date] %>
+        </p>
+      </div>
 
-        <div class="photo-timeline-viewer"
-             data-photo-timeline
-             data-photos="<%= raw(
-               @photo_timeline.photos.map { |photo|
-                 {
-                   url: url_for(photo[:attachment]),
-                   date: photo[:formatted_date]
-                 }
-               }.to_json
-             ) %>">
+      <div class="photo-comparison"
+           data-photo-comparison>
+        <div class="photo-comparison-image-wrap">
+          <%= image_tag @photo_timeline.oldest_photo[:attachment],
+              class: "photo-comparison-image base-image" %>
 
-          <div class="photo-card">
-            <p>
-              <strong><%= @photo_timeline.photo_type_label %></strong>
-              -
-              <span data-photo-timeline-date><%= @photo_timeline.oldest_photo[:formatted_date] %></span>
-            </p>
-
-            <%= image_tag @photo_timeline.oldest_photo[:attachment],
-                class: "progress-photo",
-                id: "timeline-photo-preview",
-                data: { photo_timeline_image: true } %>
+          <div class="photo-comparison-overlay" data-photo-comparison-overlay>
+            <%= image_tag @photo_timeline.newest_photo[:attachment],
+                class: "photo-comparison-image overlay-image" %>
           </div>
 
-          <% if @photo_timeline.photos.size > 1 %>
-            <div class="photo-timeline-slider-wrap">
-              <div class="photo-timeline-slider-labels">
-                <span><%= @photo_timeline.oldest_photo[:formatted_date] %></span>
-                <span><%= @photo_timeline.newest_photo[:formatted_date] %></span>
-              </div>
+          <div class="photo-comparison-divider" data-photo-comparison-divider></div>
 
-              <input type="range"
-                     min="0"
-                     max="<%= @photo_timeline.photos.size - 1 %>"
-                     value="0"
-                     step="1"
-                     class="photo-timeline-slider"
-                     data-photo-timeline-slider>
-            </div>
-          <% end %>
+          <div class="photo-comparison-label oldest-label">
+            Oldest
+          </div>
+
+          <div class="photo-comparison-label newest-label">
+            Most Recent
+          </div>
         </div>
+
+        <input type="range"
+               min="0"
+               max="100"
+               value="50"
+               class="photo-comparison-slider"
+               data-photo-comparison-slider>
+      </div>
+    <% elsif @photo_timeline.any_photos? %>
+      <p>
+        Only one <%= @photo_timeline.photo_type_label.downcase %> photo is available so far.
+        Upload at least one older and one newer photo to compare progress.
+      </p>
+
+      <div class="photo-card">
+        <p><strong><%= @photo_timeline.photo_type_label %></strong></p>
+        <%= image_tag @photo_timeline.newest_photo[:attachment], class: "progress-photo" %>
       </div>
     <% else %>
       <p>No <%= @photo_timeline.photo_type_label.downcase %> photos yet.</p>

--- a/app/views/profiles/_photo_timeline.html.erb
+++ b/app/views/profiles/_photo_timeline.html.erb
@@ -1,0 +1,44 @@
+<%= turbo_frame_tag "profile_photo_timeline" do %>
+  <div class="detail-card">
+    <div class="chart-card-header">
+      <h2>Progress Photo Timeline</h2>
+
+      <div class="chart-toggle-group">
+        <% ProfilePhotoTimeline::PHOTO_TYPES.each do |type| %>
+          <%= link_to type.delete_suffix("_photo").humanize,
+              profile_path(@profile, photo_type: type),
+              class: "chart-toggle-button #{'active' if @photo_type == type}",
+              data: { turbo_frame: "profile_photo_timeline" } %>
+        <% end %>
+      </div>
+    </div>
+
+    <% if @photo_timeline.any_photos? %>
+      <div class="photo-timeline-shell">
+        <div class="photo-timeline-meta">
+          <p>
+            <strong>Showing:</strong>
+            <%= @photo_timeline.photo_type_label %>
+          </p>
+          <p>
+            <strong>Oldest:</strong>
+            <%= @photo_timeline.oldest_photo[:formatted_date] %>
+          </p>
+          <p>
+            <strong>Most Recent:</strong>
+            <%= @photo_timeline.newest_photo[:formatted_date] %>
+          </p>
+        </div>
+
+        <div class="photo-timeline-viewer">
+          <div class="photo-card">
+            <p><strong><%= @photo_timeline.photo_type_label %></strong></p>
+            <%= image_tag @photo_timeline.newest_photo[:attachment], class: "progress-photo", id: "timeline-photo-preview" %>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <p>No <%= @photo_timeline.photo_type_label.downcase %> photos yet.</p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -23,6 +23,8 @@
   </div>
 </div>
 
+<%= render "photo_timeline" %>
+
 <h2>Check-ins</h2>
 
 <% if @check_ins.any? %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -25,7 +25,7 @@
 
 <%= render "photo_timeline" %>
 
-<h2>Check-ins</h2>
+<h2 style="padding-top: 0.5rem;">Check-ins</h2>
 
 <% if @check_ins.any? %>
   <div class="check-in-grid">


### PR DESCRIPTION
## **Summary**

This PR introduces a new progress photo comparison feature on the profile page, allowing users to visually compare their earliest and most recent check-in photos for each view (Front, Side, Back).

### **New Feature: Photo Comparison Slider**
- Added an interactive before/after comparison slider
- Displays:
  - Oldest photo as the base image
  - Most recent photo as an overlay
- Users can drag a slider directly over the image to reveal progress changes
- Uses `clip-path` for smooth, accurate image reveal without distortion

### **Photo Type Filtering**
- Added toggle buttons for:
  - Front
  - Side
  - Back
- Uses Turbo Frames to update the comparison without a full page reload

### **Responsive Design**
- Optimized layout for both desktop and mobile:
  - Full-width on mobile
  - Constrained and centered on larger screens
- Ensured consistent alignment between:
  - Toggle buttons
  - Comparison image

### **UX Improvements**
- Centered toggle controls above the image for better visual flow
- Added labeled states for “Oldest” and “Most Recent”
- Improved slider usability by overlaying interaction directly on the image
- Added fallback states for:
  - No photos
  - Only one photo available

### **Architecture**
- Introduced `ProfilePhotoTimeline` service to encapsulate:
  - Photo filtering by type
  - Chronological ordering
  - Oldest/newest selection
- Keeps view and controller logic clean and focused