### PR TITLE
Fix deployment failure on Heroku by updating the `Gemfile.lock` to support Linux platforms.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
     nokogiri (1.19.2-x86_64-darwin)
       racc (~> 1.4)
     pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -315,6 +316,7 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
+  X86_64-linux
   x86_64-darwin-23
 
 DEPENDENCIES


### PR DESCRIPTION
## Summary

- Added `x86_64-linux` platform to `Gemfile.lock`
- Ensured dependencies can be installed in Heroku’s Linux-based environment

## Context

Heroku builds run on Linux, but the lockfile only included a macOS platform (`x86_64-darwin-23`), causing Bundler to fail during deployment.
