### PR TITLE
Run add platform ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
     matrix (0.4.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -187,10 +188,13 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.19.2-x86_64-darwin)
       racc (~> 1.4)
+    pg (1.6.3)
     pg (1.6.3-x86_64-darwin)
-    pg (1.6.3-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -317,6 +321,7 @@ GEM
 
 PLATFORMS
   X86_64-linux
+  ruby
   x86_64-darwin-23
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
-  X86_64-linux
+  x86_64-linux
   ruby
   x86_64-darwin-23
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,9 +320,9 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
-  x86_64-linux
   ruby
   x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3


### PR DESCRIPTION
## Summary

- Added generic `ruby` platform for broader compatibility to fix Heroku bundler issues

