### PR TITLE
Fix dark mode background overflow

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -125,10 +125,13 @@
    Base
 ========================================================= */
 
-html,
-body,
-body.app-body,
-.page-shell {
+html {
+  min-height: 100%;
+  background: var(--page-bg);
+}
+
+body {
+  min-height: 100vh;
   background: var(--page-bg);
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="<%= theme_classes %>">
   <head>
     <title>BodMetriks</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
## Summary

- Applied theme classes to the `<html>` element to ensure CSS variables affect the full viewport
- Fixed issue where areas outside main content (below page content) remained white in dark mode
- Updated global background styles to use `var(--page-bg)` on both `html` and `body`
- Ensured consistent background rendering across browsers and screen sizes

### Result
Dark mode now correctly applies to the entire page, including areas beyond the main content.