### PR TITLE
Add GitHub Actions CI for test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - staging
+      - main
+  push:
+    branches:
+      - staging
+      - main
+
+jobs:
+  test:
+    name: RSpec
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: fitness_tracker_rails_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/fitness_tracker_rails_test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Prepare database
+        run: bin/rails db:schema:load
+
+      - name: Run tests
+        run: bundle exec rspec


### PR DESCRIPTION
## **Summary**

This PR introduces a GitHub Actions workflow to automatically run the test suite on pushes and pull requests to `staging` and `main`.

### **CI Setup**
- Added GitHub Actions workflow at `.github/workflows/ci.yml`
- Configured workflow to trigger on:
  - Pull requests to `staging` and `main`
  - Pushes to `staging` and `main`
